### PR TITLE
Fix display of time elapsed for simulation

### DIFF
--- a/deck/main.cc
+++ b/deck/main.cc
@@ -90,7 +90,7 @@ main( int argc,
     int  s = (int)elapsed, m  = s/60, h  = m/60, d  = m/24, w = d/ 7;
     /**/ s -= m*60,        m -= h*60, h -= d*24, d -= w*7;
     log_printf( "*** Done (%gs / %iw:%id:%ih:%im:%is elapsed)\n",
-                elapsed, w, d, m, h, s );
+                elapsed, w, d, h, m, s );
   }
 
   // Cleaning up


### PR DESCRIPTION
Prior to fix, log messages recording time elapsed had minutes and hours swapped.