### PR TITLE
Fix calculation of days for elapsed time

### DIFF
--- a/deck/main.cc
+++ b/deck/main.cc
@@ -87,7 +87,7 @@ main( int argc,
   while( simulation->advance() ); 
   elapsed = wallclock() - elapsed;
   if( world_rank==0 ) {
-    int  s = (int)elapsed, m  = s/60, h  = m/60, d  = m/24, w = d/ 7;
+    int  s = (int)elapsed, m  = s/60, h  = m/60, d  = h/24, w = d/ 7;
     /**/ s -= m*60,        m -= h*60, h -= d*24, d -= w*7;
     log_printf( "*** Done (%gs / %iw:%id:%ih:%im:%is elapsed)\n",
                 elapsed, w, d, h, m, s );


### PR DESCRIPTION
Prior to fix, days were derived using scaling factor for hours to days
but calculation utilizes minutes.