### PR TITLE
Takizuka-Abe collision operator

### DIFF
--- a/sample/collisions/takizuka-abe
+++ b/sample/collisions/takizuka-abe
@@ -1,0 +1,163 @@
+// Demonstrates how to use the Takizuka-Abe collision model to simulate
+// an electron beam slowing down in a background plasma.
+
+double
+mu(double x) {
+  // Computes the definite integral
+  //  mu(x) = 2/sqrt(pi) int_0^x sqrt(y) exp(-y) dy
+
+  double dx, x0 = 0, z = 0;
+  if(x > 10) {
+    x0 = 10;
+    z = mu(x0);
+  }
+
+  dx = (x-x0)/1000;
+  for(int i=0 ; i < 1000 ; ++i) {
+    z  += dx*sqrt(x0/M_PI)*exp(-x0);
+    x0 += dx;
+    z  += dx*sqrt(x0/M_PI)*exp(-x0);
+  }
+  return z;
+}
+
+begin_globals {
+  int ncoll;
+};
+
+begin_initialization {
+
+  // Simulation parameters
+
+  double mime        = 100;    // Ion to electron mass ratio
+  double vthe        = 0.01;   // Electron thermal speed in c
+  double Ebeam       = 1;      // Beam energy in Te
+  double nbeam       = 0.01;   // Beam density relative to background
+  double nu0         = 1e-2;   // Base collision frequency
+  double beam_weight = 1;      // Stat. weight of the beam realtive to background
+  int nppc           = 100000; // Particles/species/cell in the background
+  int ncoll          = 1;      // How often to collide particles in steps
+  int nstep          = 10;     // Number of steps to run for
+
+  // Setup
+  double dt = 0.98 * courant_length(1, 1, 1, 3, 3, 3);
+
+  define_units( 1, 1 );
+  define_timestep( dt );
+  define_periodic_grid( 0, 0, 0,   // Grid low corner
+                        1, 1, 1,   // Grid high corner
+                        3, 3, 3,   // Grid resolution
+                        1, 1, 1 ); // Processor configuration
+  define_material("vacuum",1.0,1.0,0.0);
+  define_field_array();
+  set_region_field(everywhere, 0, 0, 0, 0, 0, 0);
+
+  // Define the particle species.        name         q    m   Nmax  Nm Sort In-place
+  int Nback = grid->nx*grid->ny*grid->nz * nppc;
+  int Nbeam = nbeam*Nback/beam_weight;
+  species_t * electron = define_species( "electron", -1,    1, Nback, -1, ncoll, 0 ),
+            * ion      = define_species( "ion",       1, mime, Nback, -1, ncoll, 0 ),
+            * beam     = define_species( "beam",     -1,    1, Nbeam, -1, ncoll, 0 );
+
+
+  // Load the particles.
+  double weight = 1/Nback;
+  double vthi   = vthe / sqrt(mime);
+  double vbeam  = 2*sqrt(Ebeam)*vthe;
+
+  repeat(Nback){
+
+    double x = uniform( rng(0), 0, 1 );
+    double y = uniform( rng(0), 0, 1 );
+    double z = uniform( rng(0), 0, 1 );
+
+    inject_particle( electron, x, y, z,
+                     normal(  rng(0), 0, vthe ),
+                     normal(  rng(0), 0, vthe ),
+                     normal(  rng(0), 0, vthe ),
+                     weight, 0, 0 );
+
+    inject_particle( ion, x, y, z,
+                     normal(  rng(0), 0, vthi ),
+                     normal(  rng(0), 0, vthi ),
+                     normal(  rng(0), 0, vthi ),
+                     weight, 0, 0 );
+
+  }
+
+  repeat(Nbeam){
+
+    double x = uniform( rng(0), 0, 1 );
+    double y = uniform( rng(0), 0, 1 );
+    double z = uniform( rng(0), 0, 1 );
+    inject_particle( beam, x, y, z, vbeam, 0, 0, weight*beam_weight, 0, 0 );
+
+  }
+
+  // Create the collision operators
+  define_collision_op(takizuka_abe("ee_bulk", electron, electron, entropy, nu0, ncoll));
+  define_collision_op(takizuka_abe("ei_bulk", electron, ion     , entropy, nu0, ncoll));
+  define_collision_op(takizuka_abe("ee_beam", electron, beam    , entropy, nu0, ncoll));
+  define_collision_op(takizuka_abe("ei_beam", ion,      beam    , entropy, nu0, ncoll));
+  // Ignore beam-beam collisions for benchmarking.
+
+  // Finalize the simulation paramters
+  num_step             = nstep;
+  status_interval      = 200;
+  sync_shared_interval = -status_interval/2;
+  clean_div_e_interval = -status_interval/2;
+  clean_div_b_interval = -status_interval/2;
+
+  // For informational purposes, compute the theoretical beam energy loss rate.
+  // With the normalization conventions used here, this is related to nu0 via
+  //
+  // nu_e^{e/s} = 4 me/m_s mu(x)/x nu0 (me c^2/Ebeam)^(3/2)
+  //
+  // where x =  m_s Ebeam / me T and the function
+  //
+  // mu(x) = 2/sqrt(pi) int_0^x exp(-y) sqrt(y) dy
+
+  // Energy loss rate due to electron collisions.
+  double x = Ebeam;
+  double nu_e = 4 * mu(x)/x * nu0 * pow(Ebeam*vthe*vthe, -1.5);
+
+  x = Ebeam * mime;
+  double nu_i = 4 * mu(x)/x * nu0 * pow(Ebeam*vthe*vthe, -1.5);
+
+  sim_log("Theoretical energy loss rate = " << nu_e + nu_i);
+
+  // Set globals
+  global->ncoll = ncoll;
+
+}
+
+begin_diagnostics {
+
+  static double beam_energy = energy_p( find_species("beam"),
+                                        interpolator_array );
+
+  if( step() % global->ncoll ) {
+
+    double e    = energy_p(find_species("beam"), interpolator_array);
+    double nu_e = (2*(e-beam_energy)/(e+beam_energy))/(grid->dt*global->ncoll);
+    sim_log("Beam energy = " << e << ", energy loss rate = " << nu_e);
+    beam_energy = e;
+
+  }
+
+}
+
+begin_particle_injection {
+}
+
+begin_current_injection {
+}
+
+begin_field_injection {
+  // Force field to 0 to prevent grid instabilities since dx may be >> Debye
+  set_region_field(everywhere, 0, 0, 0, 0, 0, 0);
+}
+
+begin_particle_collisions {
+
+}

--- a/sample/collisions/takizuka-abe
+++ b/sample/collisions/takizuka-abe
@@ -2,9 +2,14 @@
 // an electron beam slowing down in a background plasma.
 
 double
+mu_prime(double x) {
+  return 2*sqrt(x/M_PI)*exp(-x);
+}  
+
+double
 mu(double x) {
   // Computes the definite integral
-  //  mu(x) = 2/sqrt(pi) int_0^x sqrt(y) exp(-y) dy
+  // mu(x) = 2/sqrt(pi) int_0^x sqrt(y) exp(-y) dy
 
   double dx, x0 = 0, z = 0;
   if(x > 10) {
@@ -14,9 +19,9 @@ mu(double x) {
 
   dx = (x-x0)/1000;
   for(int i=0 ; i < 1000 ; ++i) {
-    z  += dx*sqrt(x0/M_PI)*exp(-x0);
+    z  += 0.5*dx*mu_prime(x0);
     x0 += dx;
-    z  += dx*sqrt(x0/M_PI)*exp(-x0);
+    z  += 0.5*dx*mu_prime(x0);
   }
   return z;
 }
@@ -30,11 +35,11 @@ begin_initialization {
   // Simulation parameters
 
   double mime        = 100;    // Ion to electron mass ratio
-  double vthe        = 0.01;   // Electron thermal speed in c
-  double Ebeam       = 1;      // Beam energy in Te
+  double vthe        = 0.1;    // Electron thermal speed in c
+  double Ebeam       = 0.5;    // Beam energy in Te
   double nbeam       = 0.01;   // Beam density relative to background
   double nu0         = 1e-2;   // Base collision frequency
-  double beam_weight = 1;      // Stat. weight of the beam realtive to background
+  double beam_weight = 10;     // Stat. weight of the beam realtive to background
   int nppc           = 100000; // Particles/species/cell in the background
   int ncoll          = 1;      // How often to collide particles in steps
   int nstep          = 10;     // Number of steps to run for
@@ -61,9 +66,9 @@ begin_initialization {
 
 
   // Load the particles.
-  double weight = 1/Nback;
+  double weight = 1/(double) Nback;
   double vthi   = vthe / sqrt(mime);
-  double vbeam  = 2*sqrt(Ebeam)*vthe;
+  double vbeam  = sqrt(2*Ebeam)*vthe;
 
   repeat(Nback){
 
@@ -95,10 +100,17 @@ begin_initialization {
   }
 
   // Create the collision operators
-  define_collision_op(takizuka_abe("ee_bulk", electron, electron, entropy, nu0, ncoll));
-  define_collision_op(takizuka_abe("ei_bulk", electron, ion     , entropy, nu0, ncoll));
-  define_collision_op(takizuka_abe("ee_beam", electron, beam    , entropy, nu0, ncoll));
-  define_collision_op(takizuka_abe("ei_beam", ion,      beam    , entropy, nu0, ncoll));
+  // 
+  // On input, nu0 refers to the base collision frequency of the thermal
+  // plasma, but for the collision operator we need to normalize this
+  // by mc2 instead of T. This amounts to rescaling nu0 by (vthe/c)^3
+
+  double nu0_c3 = nu0 * pow(vthe, 3);
+
+  define_collision_op(takizuka_abe("ee_bulk", electron, electron, entropy, nu0_c3, ncoll));
+  define_collision_op(takizuka_abe("ei_bulk", electron, ion     , entropy, nu0_c3, ncoll));
+  define_collision_op(takizuka_abe("ee_beam", electron, beam    , entropy, nu0_c3, ncoll));
+  define_collision_op(takizuka_abe("ei_beam", ion,      beam    , entropy, nu0_c3, ncoll));
   // Ignore beam-beam collisions for benchmarking.
 
   // Finalize the simulation paramters
@@ -108,23 +120,38 @@ begin_initialization {
   clean_div_e_interval = -status_interval/2;
   clean_div_b_interval = -status_interval/2;
 
-  // For informational purposes, compute the theoretical beam energy loss rate.
-  // With the normalization conventions used here, this is related to nu0 via
-  //
-  // nu_e^{e/s} = 4 me/m_s mu(x)/x nu0 (me c^2/Ebeam)^(3/2)
-  //
-  // where x =  m_s Ebeam / me T and the function
-  //
-  // mu(x) = 2/sqrt(pi) int_0^x exp(-y) sqrt(y) dy
+  // For informational purposes, compute the transport rates for the beam.
+  // See e.g., the Plasma Formulary for these rates.
+  double x;
+  double nu_beam = nu0 * pow(Ebeam, -1.5);
 
-  // Energy loss rate due to electron collisions.
-  double x = Ebeam;
-  double nu_e = 4 * mu(x)/x * nu0 * pow(Ebeam*vthe*vthe, -1.5);
+  // Rates due to collisions with electrons.
+  x = Ebeam;
+  double nu_se = -2 * mu(x) * nu_beam;
+  double nu_de = 2 * ( (1-0.5/x)*mu(x) + mu_prime(x) ) * nu_beam;
+  double nu_te = -2 * ( mu(x) - mu_prime(x) ) * nu_beam;
 
+  // Rates due to collisions with ions
   x = Ebeam * mime;
-  double nu_i = 4 * mu(x)/x * nu0 * pow(Ebeam*vthe*vthe, -1.5);
+  double nu_si = -(1+1/mime)*mu(x) * nu_beam;
+  double nu_di = 2 * ( (1-0.5/x)*mu(x) + mu_prime(x) ) * nu_beam;
+  double nu_ti = -2 * ( mu(x)/mime - mu_prime(x) ) * nu_beam;
 
-  sim_log("Theoretical energy loss rate = " << nu_e + nu_i);
+  // Log the paramters.
+
+  sim_log("Electron Beam Parameters");
+  sim_log("-----------------------------------------------");
+  sim_log("Ion / electron mass ratio    = " << mime         );
+  sim_log("Beam energy / temperature    = " << Ebeam        );
+  sim_log("Beam density / background    = " << nbeam        );
+  sim_log("Beam weights / backgorund    = " << beam_weight  );
+  sim_log("Background particles         = " << Nback        );
+  sim_log("Beam particles               = " << Nbeam        );
+  sim_log("-----------------------------------------------");
+  sim_log("Theoretical slow down  rate  = " << nu_se + nu_si);
+  sim_log("Theoretical deflection rate  = " << nu_de + nu_di);
+  sim_log("Theoretical energy loss rate = " << nu_te + nu_ti);
+  sim_log("-----------------------------------------------");
 
   // Set globals
   global->ncoll = ncoll;
@@ -133,20 +160,57 @@ begin_initialization {
 
 begin_diagnostics {
 
-  static double beam_energy = energy_p( find_species("beam"),
-                                        interpolator_array );
+  if( step() % global->ncoll == 0) {
 
-  if( step() % global->ncoll ) {
+    // Find the beam and collect the hydro moments
+    species_t * beam = find_species("beam");
+    clear_hydro_array( hydro_array );
+    accumulate_hydro_p( hydro_array, beam, interpolator_array );
+    synchronize_hydro_array( hydro_array );
 
-    double e    = energy_p(find_species("beam"), interpolator_array);
-    double nu_e = (2*(e-beam_energy)/(e+beam_energy))/(grid->dt*global->ncoll);
-    sim_log("Beam energy = " << e << ", energy loss rate = " << nu_e);
-    beam_energy = e;
+    // Average over the volume.
+    int i, j, k;
+    hydro_t avg = {0};
+    double ncells = grid->nx * grid->ny * grid->nz; 
+    for( k=1; k <= grid->nz ; ++k)
+      for( j=1; j <= grid->ny ; ++j)
+        for( i=1; i <= grid->nx ; ++i) {
+	    	  
+	  hydro_t cell = hydro_array->h[ voxel(i,j,k) ];
+	  avg.jx  += cell.jx  / ncells;
+	  avg.jy  += cell.jy  / ncells;
+	  avg.jz  += cell.jz  / ncells;
+	  avg.ke  += cell.ke  / ncells;
+	  avg.txx += cell.txx / ncells;
+	  avg.tyy += cell.tyy / ncells;
+	  avg.tzz += cell.tzz / ncells;
 
-  }
+	}
 
-}
+    // Now log the slow-down rate.
+    static double jx = avg.jx;
+    double nu_s = (2*(avg.jx-jx)/(avg.jx+jx))/(grid->dt*global->ncoll);
+    jx = avg.jx;
 
+    // Log the deflection rate and the energy loss rate.
+    static double Tperp = avg.tyy + avg.tzz;
+    static double Tbeam = avg.txx + avg.tyy + avg.tzz;
+    
+    double Tp = avg.tyy + avg.tzz;
+    double T  = Tp + avg.txx;
+    double nu_d = (2*(Tp-Tperp)/(T+Tbeam))/(grid->dt*global->ncoll);
+    double nu_t = (2*(T -Tbeam)/(T+Tbeam))/(grid->dt*global->ncoll);
+    Tperp = Tp;
+    Tbeam = T;
+
+    sim_log("Beam current = " << jx << ", slow down rate   = " << nu_s);
+    sim_log("Beam Tperp   = " << Tp << ", deflection rate  = " << nu_d);
+    sim_log("Beam energy  = " << T  << ", energy loss rate = " << nu_t);
+
+  } 
+		  
+}	     
+	     	  
 begin_particle_injection {
 }
 

--- a/src/collision/collision.h
+++ b/src/collision/collision.h
@@ -47,6 +47,9 @@ append_collision_op( collision_op_t * cop,
    transfer rate (i.e., "the" collision rate) is related to nu0 via
 
    nu_s = 4 (mc^2 / T)^3 nu0 / 3 sqrt(pi)
+
+   The paper defines variance ~= sqrt(2)*nu_0, and here we expect the user to
+   pass us the base cvar
 */
 
 collision_op_t *
@@ -54,7 +57,7 @@ takizuka_abe( const char       * RESTRICT name,
               /**/  species_t  * RESTRICT spi,
               /**/  species_t  * RESTRICT spj,
               /**/  rng_pool_t * RESTRICT rp,
-              const double                nu0,
+              const double                cvar0,
               const int                   interval );
 
 /* In langevin.c */

--- a/src/collision/collision.h
+++ b/src/collision/collision.h
@@ -32,12 +32,37 @@ collision_op_t *
 append_collision_op( collision_op_t * cop,
                      collision_op_t ** cop_list );
 
+/* In takizuka_abe.c */
+
+/* The Takizuka-Abe collision model is based on Takizuka and Abe, JCP 1977
+   and efficiently models small-angle Coulomb scattering by randomly pairing
+   particles. On average, each particle is scattered once per call. The model
+   is fully defined by a single parameter, the base collision frequency nu0.
+   In SI units, nu0 is defined by
+
+   nu0 = log(Lambda) / 8 pi sqrt(2) c^3 eps0^2
+
+   where log(Lambda) is the Coulomb logarithm. For a thermal species with
+   temperature T, normalized mass m and charge q, the self-scattering momentum
+   transfer rate (i.e., "the" collision rate) is related to nu0 via
+
+   nu_s = 4 (mc^2 / T)^3 nu0 / 3 sqrt(pi)
+*/
+
+collision_op_t *
+takizuka_abe( const char       * RESTRICT name,
+              /**/  species_t  * RESTRICT spi,
+              /**/  species_t  * RESTRICT spj,
+              /**/  rng_pool_t * RESTRICT rp,
+              const double                nu0,
+              const int                   interval );
+
 /* In langevin.c */
 
 /* The most basic collision model (but implemented with numerical
    sophistication).  nu is the collision frequency of the particles
    with some unresolved stationary large thermal bath.  kT is the
-   thermal bath temperature.  This method is stable (e.g. if you set 
+   thermal bath temperature.  This method is stable (e.g. if you set
    nu very large, it is equivalent to resampling your particle
    normal momenta from a normal distribution with
    uth = sqrt(kT/mc)) every time this operator is applied (in MD,
@@ -115,7 +140,7 @@ typedef void
                            /**/  particle_t * RESTRICT ALIGNED(32) p,
                            /**/  rng_t      * RESTRICT rng );
 
-/* Declare a unary collision model with the given microscopic physics. 
+/* Declare a unary collision model with the given microscopic physics.
    params must be a registered object or NULL.  Every particle is
    tested for collision on every "interval" timesteps.  */
 
@@ -178,7 +203,7 @@ unary_collision_model( const char       * RESTRICT name,
    boost factor and has the manifestly covariant expression s =
    Ui.Uj - 1 where Ui = (gamma_i,ui) and Uj = (gamma_j,uj) are the
    normalized 4-momenta of particle i and particle j respectively
-   and the Minkowski 4-dot product has a +--- signature. 
+   and the Minkowski 4-dot product has a +--- signature.
 
    The basic control flow for a unary_collision_func_t should be:
 
@@ -229,7 +254,7 @@ typedef void
                             /**/  rng_t      * RESTRICT rng,
                             int type );
 
-/* Declare a binary collision model with the given microscopic physics. 
+/* Declare a binary collision model with the given microscopic physics.
    params must be a registered object or NULL.  A particle in a species
    will be tested for collision on average at least "sample" times every
    "interval" timesteps.  */

--- a/src/collision/pipeline/collision_pipeline.h
+++ b/src/collision/pipeline/collision_pipeline.h
@@ -4,6 +4,7 @@
 #include "../binary.h"
 #include "../langevin.h"
 #include "../unary.h"
+#include "../takizuka_abe.h"
 
 void
 binary_pipeline_scalar( binary_collision_model_t * RESTRICT cm,

--- a/src/collision/pipeline/collision_pipeline.h
+++ b/src/collision/pipeline/collision_pipeline.h
@@ -20,4 +20,9 @@ unary_pipeline_scalar( unary_collision_model_t * RESTRICT cm,
                        int pipeline_rank,
                        int n_pipeline );
 
+void
+takizuka_abe_pipeline_scalar( takizuka_abe_t * RESTRICT cm,
+                              int pipeline_rank,
+                              int n_pipeline );
+
 #endif /* _collision_pipeline_h_ */

--- a/src/collision/pipeline/takizuka_abe_pipeline.c
+++ b/src/collision/pipeline/takizuka_abe_pipeline.c
@@ -1,0 +1,223 @@
+#define IN_collision
+
+/* #define HAS_V4_PIPELINE */
+
+#include "collision_pipeline.h"
+
+#include "../takizuka_abe.h"
+
+#include "../../util/pipelines/pipelines_exec.h"
+
+#define CMOV(a,b) if(t0<t1) a=b
+
+// Branchless and direction-agnositc method for computing momentum transfer.
+#define takizuka_abe_collision(PI,PJ,mu_i,mu_j,std,rng) do {            \
+    particle_t * const RESTRICT pi = (PI);                              \
+    particle_t * const RESTRICT pj = (PJ);                              \
+    float dd, ur, urx, ury, urz, tx, ty, tz, t0, t1, t2, wi, wj, stack[3]; \
+    int d0, d1, d2;                                                     \
+                                                                        \
+    urx = pi->ux - pj->ux;                                              \
+    ury = pi->uy - pj->uy;                                              \
+    urz = pi->uz - pj->uz;                                              \
+    wi  = pi->w;                                                        \
+    wj  = pj->w;                                                        \
+                                                                        \
+    /* There are lots of ways to formulate T vector formation    */     \
+    /* This has no branches (but uses L1 heavily)                */     \
+                                                                        \
+    t0 = urx*urx;      d0=0;       d1=1;       d2=2;       t1=t0;  ur  = t0; \
+    t0 = ury*ury; CMOV(d0,1); CMOV(d1,2); CMOV(d2,0); CMOV(t1,t0); ur += t0; \
+    t0 = urz*urz; CMOV(d0,2); CMOV(d1,0); CMOV(d2,1);              ur += t0; \
+    ur = sqrtf( ur );                                                   \
+                                                                        \
+    stack[0] = urx;                                                     \
+    stack[1] = ury;                                                     \
+    stack[2] = urz;                                                     \
+    t1  = stack[d1];                                                    \
+    t2  = stack[d2];                                                    \
+    t0  = 1 / sqrtf( t1*t1 + t2*t2 + FLT_MIN );                         \
+    stack[d0] =  0;                                                     \
+    stack[d1] =  t0*t2;                                                 \
+    stack[d2] = -t0*t1;                                                 \
+    tx = stack[0];                                                      \
+    ty = stack[1];                                                      \
+    tz = stack[2];                                                      \
+                                                                        \
+    t0 = 1;                                                             \
+    t2 = 1/ur;                                                          \
+    t1 = std*sqrtf(t2)*t2;                                              \
+    CMOV(t1,t0);                                                        \
+    dd = t1*frandn(rng);                                                \
+                                                                        \
+    t0 = 2*dd/(1+dd*dd);                                                \
+    t1 = 2*M_PI*frand_c0(rng);                                          \
+    t2 = t0*sin(t1);                                                    \
+    t1 = t0*ur*cos(t1);                                                 \
+    t0 *= -dd;                                                          \
+                                                                        \
+    /* stack = (1 - cos theta) u + |u| sin theta Tperp */               \
+    stack[0] = (t0*urx + t1*tx) + t2*( ury*tz - urz*ty );               \
+    stack[1] = (t0*ury + t1*ty) + t2*( urz*tx - urx*tz );               \
+    stack[2] = (t0*urz + t1*tz) + t2*( urx*ty - ury*tx );               \
+                                                                        \
+    /* Handle unequal particle weights. */                              \
+    t0 = frand_c0(rng);                                                 \
+    if(wi < wj) mu_j = wj*t0 <= wi ? mu_j : 0 ;                         \
+    if(wj < wi) mu_i = wi*t0 <= wj ? mu_i : 0 ;                         \
+                                                                        \
+    pi->ux += mu_i*stack[0];                                            \
+    pi->uy += mu_i*stack[1];                                            \
+    pi->uz += mu_i*stack[2];                                            \
+    pj->ux -= mu_j*stack[0];                                            \
+    pj->uy -= mu_j*stack[1];                                            \
+    pj->uz -= mu_j*stack[2];                                            \
+                                                                        \
+  } while(0)
+
+void
+takizuka_abe_pipeline_scalar( takizuka_abe_t * RESTRICT cm,
+                              int pipeline_rank,
+                              int n_pipeline ) {
+  if( pipeline_rank==n_pipeline ) return; /* No host straggler cleanup */
+
+  /**/  species_t    * RESTRICT spi           = cm->spi;
+  /**/  species_t    * RESTRICT spj           = cm->spj;
+  /**/  rng_t        * RESTRICT rng           = cm->rp->rng[ pipeline_rank ];
+  const grid_t       * RESTRICT g             = spi->g;
+
+  /**/  particle_t   * RESTRICT ALIGNED(128) spi_p         = spi->p;
+  const int          * RESTRICT ALIGNED(128) spi_partition = spi->partition;
+
+  /**/  particle_t   * RESTRICT ALIGNED(128) spj_p         = spj->p;
+  const int          * RESTRICT ALIGNED(128) spj_partition = spj->partition;
+
+  const float dtinterval_dV = ( g->dt * (float)cm->interval ) / g->dV;
+  const float mu    = (spi->m*spj->m)/(spi->m+spj->m);
+  const float mu_i  = spj->m/(spi->m+spj->m);
+  const float mu_j  = spi->m/(spi->m+spj->m);
+  const double cvar = sqrt(2) * cm->nu0 * (spi->q*spi->q*spj->q*spj->q) / (mu*mu);
+
+  particle_t ptemp;
+  float var, std, density_k, density_l;
+  int i, j, ii, rn, v, v1, k, k0, k1, nk, l, l0, nl, size_k, size_l;
+
+  /* Stripe the (mostly non-ghost) voxels over threads for load balance */
+
+  v  = VOXEL( 0,0,0,             g->nx,g->ny,g->nz ) + pipeline_rank;
+  v1 = VOXEL( g->nx,g->ny,g->nz, g->nx,g->ny,g->nz ) + 1;
+  for( ; v<v1; v+=n_pipeline ) {
+
+    /* Find the species i computational particles, k, and the species j
+       computational particles, l, in this voxel, determine the number
+       of computational particle pairs, np and the number of candidate
+       pairs, nc, to test for collisions within this voxel.  Also,
+       split the range of the fastest integer rng into intervals
+       suitable for sampling pairs. */
+
+    k0 = spi_partition[v  ];
+    nk = spi_partition[v+1] - k0;
+    if( !nk ) continue; /* Nothing to do */
+
+    // Compute the species density for this cell while doing a Fisher-Yates
+    // shuffle. NOTE: shuffling here instead of computing random indicies allows
+    // for better optimization of the collision loop and an overall speedup.
+    density_k = 0;
+    k1 = k0+nk;
+    for(i=k0 ; i < k1-1 ; ++i){
+      rn = UINT32_MAX / (uint32_t)(k1-i);
+      do { j = i + (int)(uirand(rng)/rn); } while( j>=k1 );
+      ptemp = spi_p[j], spi_p[j] = spi_p[i], spi_p[i] = ptemp;
+      density_k += spi_p[i].w;
+    }
+    density_k += spi_p[i].w;
+
+    if( spi==spj ) {
+
+      if( nk%2 && nk >= 3 ) {
+        std = sqrtf(0.5*density_k*cvar*dtinterval_dV);
+        takizuka_abe_collision( spi_p + k0,
+                                spi_p + k0 + 1,
+                                mu_i, mu_j, std, rng );
+        takizuka_abe_collision( spi_p + k0,
+                                spi_p + k0 + 2,
+                                mu_i, mu_j, std, rng );
+        takizuka_abe_collision( spi_p + k0 + 1,
+                                spi_p + k0 + 2,
+                                mu_i, mu_j, std, rng );
+        nk -= 3;
+        k0 += 3;
+      }
+
+      nl = nk = nk/2;
+      l0 = k0 + nk;
+      if( !nk ) continue; /* We had exactly 1 or 3 paticles. */
+      std = sqrtf(cvar*density_k*dtinterval_dV);
+
+    } else {
+
+      l0 = spj_partition[v  ];
+      nl = spj_partition[v+1] - l0;
+      if( !nl ) continue; /* Nothing to do */
+
+      // Since spi_p is already randomized, setting spi_j to any specific
+      // permutataion will still give a perfectly valid and random set of
+      // particle pairs. Which means we can just leave it as is.
+
+      // Compute the species density for this cell.
+      density_l = 0;
+      for(i=0 ; i < nl ; ++i)
+        density_l += spj_p[l0+i].w;
+
+      // Compute the standard deviation of the collision angle.
+      std = sqrtf( cvar*(density_l > density_k ? density_k : density_l)*dtinterval_dV );
+    }
+
+    if (nk > nl) {
+
+      ii = nk/nl;
+      rn = nk - ii*nl;
+
+      for( i=0 ; i < rn ; ++i, ++l0 )
+        for( j=0 ; j <= ii ; ++j, ++k0 )
+          takizuka_abe_collision( spi_p + k0,
+                                  spj_p + l0,
+                                  mu_i, mu_j, std, rng);
+
+      for( ; i < nl ; ++i, ++l0 )
+        for( j=0 ; j < ii ; ++j, ++k0 )
+          takizuka_abe_collision( spi_p + k0,
+                                  spj_p + l0,
+                                  mu_i, mu_j, std, rng);
+
+    } else {
+
+      ii = nl/nk;
+      rn = nl - ii*nk;
+
+      for( i=0 ; i < rn ; ++i, ++k0 )
+        for( j=0 ; j <= ii ; ++j, ++l0 )
+          takizuka_abe_collision( spi_p + k0,
+                                  spj_p + l0,
+                                  mu_i, mu_j, std, rng);
+
+      for( ; i < nk ; ++i, ++k0 )
+        for( j=0 ; j < ii ; ++j, ++l0 )
+          takizuka_abe_collision( spi_p + k0,
+                                  spj_p + l0,
+                                  mu_i, mu_j, std, rng);
+
+    }
+
+  }
+
+}
+
+#undef CMOV
+#undef takizuka_abe_collision
+
+void
+apply_takizuka_abe_pipeline( takizuka_abe_t * cm ) {
+  EXEC_PIPELINES( takizuka_abe, cm, 0 );
+  WAIT_PIPELINES();
+}

--- a/src/collision/pipeline/takizuka_abe_pipeline.c
+++ b/src/collision/pipeline/takizuka_abe_pipeline.c
@@ -63,15 +63,17 @@
                                                                         \
     /* Handle unequal particle weights. */                              \
     t0 = frand_c0(rng);                                                 \
-    if(wi < wj) mu_j = wj*t0 <= wi ? mu_j : 0 ;                         \
-    if(wj < wi) mu_i = wi*t0 <= wj ? mu_i : 0 ;                         \
+    t1 = mu_i;                                                          \
+    t2 = mu_j;                                                          \
+    if(wj < wi && wi*t0 > wj) t1 = 0 ;                                  \
+    if(wi < wj && wj*t0 > wi) t2 = 0 ;                                  \
                                                                         \
-    pi->ux += mu_i*stack[0];                                            \
-    pi->uy += mu_i*stack[1];                                            \
-    pi->uz += mu_i*stack[2];                                            \
-    pj->ux -= mu_j*stack[0];                                            \
-    pj->uy -= mu_j*stack[1];                                            \
-    pj->uz -= mu_j*stack[2];                                            \
+    pi->ux += t1*stack[0];                                              \
+    pi->uy += t1*stack[1];                                              \
+    pi->uz += t1*stack[2];                                              \
+    pj->ux -= t2*stack[0];                                              \
+    pj->uy -= t2*stack[1];                                              \
+    pj->uz -= t2*stack[2];                                              \
                                                                         \
   } while(0)
 

--- a/src/collision/pipeline/takizuka_abe_pipeline.c
+++ b/src/collision/pipeline/takizuka_abe_pipeline.c
@@ -98,7 +98,7 @@ takizuka_abe_pipeline_scalar( takizuka_abe_t * RESTRICT cm,
   const float mu    = (spi->m*spj->m)/(spi->m+spj->m);
   const float mu_i  = spj->m/(spi->m+spj->m);
   const float mu_j  = spi->m/(spi->m+spj->m);
-  const double cvar = sqrt(2) * cm->nu0 * (spi->q*spi->q*spj->q*spj->q) / (mu*mu);
+  const double cvar = cm->cvar0 * (spi->q*spi->q*spj->q*spj->q) / (mu*mu);
 
   particle_t ptemp;
   float var, std, density_k, density_l;

--- a/src/collision/takizuka_abe.c
+++ b/src/collision/takizuka_abe.c
@@ -37,7 +37,6 @@ restore_takizuka_abe( void ) {
 void
 delete_takizuka_abe( collision_op_t * cop ) {
   takizuka_abe_t * cm = (takizuka_abe_t *)cop->params;
-  // UNREGISTER_OBJECT( cm );
   FREE( cm->name );
   FREE( cm );
   delete_collision_op_internal( cop );

--- a/src/collision/takizuka_abe.c
+++ b/src/collision/takizuka_abe.c
@@ -1,0 +1,76 @@
+#define IN_collision
+#include "takizuka_abe.h"
+
+/* Private interface *********************************************************/
+
+void
+apply_takizuka_abe( takizuka_abe_t * cm ){
+  if( cm->interval<1 || (cm->spi->g->step % cm->interval) ) return;
+  if( cm->spi->last_sorted!=cm->spi->g->step ) sort_p( cm->spi );
+  if( cm->spj->last_sorted!=cm->spi->g->step ) sort_p( cm->spj );
+  apply_takizuka_abe_pipeline(cm);
+}
+
+void
+checkpt_takizuka_abe( const collision_op_t * cop ) {
+  const takizuka_abe_t * cm =
+    (const takizuka_abe_t *)cop->params;
+  CHECKPT( cm, 1 );
+  CHECKPT_STR( cm->name );
+  CHECKPT_PTR( cm->spi );
+  CHECKPT_PTR( cm->spj );
+  CHECKPT_PTR( cm->rp );
+  checkpt_collision_op_internal( cop );
+}
+
+collision_op_t *
+restore_takizuka_abe( void ) {
+  takizuka_abe_t * cm;
+  RESTORE( cm );
+  RESTORE_STR( cm->name );
+  RESTORE_PTR( cm->spi );
+  RESTORE_PTR( cm->spj );
+  RESTORE_PTR( cm->rp );
+  return restore_collision_op_internal( cm );
+}
+
+void
+delete_takizuka_abe( collision_op_t * cop ) {
+  takizuka_abe_t * cm = (takizuka_abe_t *)cop->params;
+  // UNREGISTER_OBJECT( cm );
+  FREE( cm->name );
+  FREE( cm );
+  delete_collision_op_internal( cop );
+}
+
+/* Public interface **********************************************************/
+
+collision_op_t *
+takizuka_abe( const char       * RESTRICT name,
+              /**/  species_t  * RESTRICT spi,
+              /**/  species_t  * RESTRICT spj,
+              /**/  rng_pool_t * RESTRICT rp,
+              const double                nu0,
+              const int                   interval ) {
+  takizuka_abe_t * cm;
+  size_t len = name ? strlen(name) : 0;
+
+  if( !spi || !spj || spi->g!=spj->g || !rp || rp->n_rng<N_PIPELINE ) ERROR(( "Bad args" ));
+  if( len==0 ) ERROR(( "Cannot specify a nameless collision model" ));
+
+  MALLOC( cm, 1 );
+  MALLOC( cm->name, len+1 );
+  strcpy( cm->name, name );
+  cm->spi      = spi;
+  cm->spj      = spj;
+  cm->rp       = rp;
+  cm->nu0      = nu0;
+  cm->interval = interval;
+
+  return new_collision_op_internal( cm,
+                                    (collision_op_func_t)apply_takizuka_abe,
+                                    delete_takizuka_abe,
+                                    (checkpt_func_t)checkpt_takizuka_abe,
+                                    (restore_func_t)restore_takizuka_abe,
+                                    NULL );
+}

--- a/src/collision/takizuka_abe.c
+++ b/src/collision/takizuka_abe.c
@@ -49,7 +49,7 @@ takizuka_abe( const char       * RESTRICT name,
               /**/  species_t  * RESTRICT spi,
               /**/  species_t  * RESTRICT spj,
               /**/  rng_pool_t * RESTRICT rp,
-              const double                nu0,
+              const double                cvar0,
               const int                   interval ) {
   takizuka_abe_t * cm;
   size_t len = name ? strlen(name) : 0;
@@ -63,7 +63,7 @@ takizuka_abe( const char       * RESTRICT name,
   cm->spi      = spi;
   cm->spj      = spj;
   cm->rp       = rp;
-  cm->nu0      = nu0;
+  cm->cvar0      = cvar0;
   cm->interval = interval;
 
   return new_collision_op_internal( cm,

--- a/src/collision/takizuka_abe.h
+++ b/src/collision/takizuka_abe.h
@@ -1,0 +1,18 @@
+#ifndef _takizuka_abe_h_
+#define _takizuka_abe_h_
+
+#include "collision_private.h"
+
+typedef struct takizuka_abe {
+  char * name;
+  species_t  * spi;
+  species_t  * spj;
+  rng_pool_t * rp;
+  int interval;
+  double nu0;
+} takizuka_abe_t;
+
+void
+apply_takizuka_abe_pipeline( takizuka_abe_t * l );
+
+#endif /* _takizuka_abe_h_ */

--- a/src/collision/takizuka_abe.h
+++ b/src/collision/takizuka_abe.h
@@ -9,7 +9,7 @@ typedef struct takizuka_abe {
   species_t  * spj;
   rng_pool_t * rp;
   int interval;
-  double nu0;
+  double cvar0; // Base cvar0, which will later be scaled by q and mu
 } takizuka_abe_t;
 
 void

--- a/src/vpic/vpic.cc
+++ b/src/vpic/vpic.cc
@@ -7,9 +7,9 @@
  * March/April 2004 - Heavily revised and extended from earlier V4PIC versions
  *
  */
- 
+
 #include "vpic.h"
- 
+
 /* Note that, when a vpic_simulation is created (and thus registered
    with the checkpt service), it is created empty; none of the simulation
    objects on which it depends have been created yet. (These get created
@@ -99,7 +99,7 @@ vpic_simulation::vpic_simulation() {
   //   if( n_rng<spu.n_pipeline    ) n_rng = spu.n_pipeline;
   // # endif
 
-  n_rng++; 
+  n_rng++;
 
   entropy      = new_rng_pool( n_rng, 0, 0 );
   sync_entropy = new_rng_pool( n_rng, 0, 1 );
@@ -108,9 +108,10 @@ vpic_simulation::vpic_simulation() {
   REGISTER_OBJECT( this, checkpt_vpic_simulation,
                    restore_vpic_simulation, reanimate_vpic_simulation );
 }
- 
+
 vpic_simulation::~vpic_simulation() {
   UNREGISTER_OBJECT( this );
+  delete_collision_op_list( collision_op_list );
   delete_emitter_list( emitter_list );
   delete_particle_bc_list( particle_bc_list );
   delete_species_list( species_list );
@@ -123,4 +124,3 @@ vpic_simulation::~vpic_simulation() {
   delete_rng_pool( sync_entropy );
   delete_rng_pool( entropy );
 }
- 


### PR DESCRIPTION
Adds a pipelined Takizuka-Abe collision operator using the native `collision_op_t` interface . This version fixes a couple small bugs in, and is faster than, the openmp-based deck version.

Unequal particle weights are handled the same as in `binary_collision_model` where particles are updated conditionally based on their weights. This works, but breaks momentum conservation for unequal weights.

Includes an example deck that demonstrates how to use the collision operator and implements the standard beam-plasma test for Coulomb collisions. 