### PR TITLE
Particle arrays now resized dynamically.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,8 @@ option(VPIC_PRINT_MORE_DIGITS "Print more digits in VPIC timer info" OFF)
 
 option(ENABLE_OPENSSL "Enable OpenSSL support for checksums" OFF)
 
+option(DISABLE_DYNAMIC_RESIZING "Prevent particle arrays from dynamically resizing during a run" OFF)
+
 #------------------------------------------------------------------------------#
 # Create include and link aggregates
 #
@@ -95,6 +97,10 @@ endif("${CMAKE_BUILD_TYPE}" STREQUAL "RelWithDebInfo")
 
 string(REPLACE ";" " " string_libraries "${MPI_CXX_LIBRARIES} ${MPI_C_LIBRARIES}")
 set(VPIC_CXX_LIBRARIES "${string_libraries}")
+
+if(DISABLE_DYNAMIC_RESIZING)
+  add_definitions(-DDISABLE_DYNAMIC_RESIZING)
+endif(DISABLE_DYNAMIC_RESIZING)
 
 #------------------------------------------------------------------------------#
 # OpenSSL

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,10 @@ option(ENABLE_OPENSSL "Enable OpenSSL support for checksums" OFF)
 
 option(DISABLE_DYNAMIC_RESIZING "Prevent particle arrays from dynamically resizing during a run" OFF)
 
+# option to set minimum number of particles
+set(SET_MIN_NUM_PARTICLES AUTO CACHE STRING "Select minimum number of particles to use, if using dynamic particle array resizing")
+
+
 #------------------------------------------------------------------------------#
 # Create include and link aggregates
 #
@@ -102,6 +106,9 @@ if(DISABLE_DYNAMIC_RESIZING)
   add_definitions(-DDISABLE_DYNAMIC_RESIZING)
 endif(DISABLE_DYNAMIC_RESIZING)
 
+if(NOT SET_MIN_NUM_PARTICLES STREQUAL "AUTO")
+    add_definitions(-DMIN_NP=${SET_MIN_NUM_PARTICLES})
+endif()
 #------------------------------------------------------------------------------#
 # OpenSSL
 #------------------------------------------------------------------------------#

--- a/src/boundary/boundary_p.cc
+++ b/src/boundary/boundary_p.cc
@@ -25,6 +25,12 @@
 using namespace v4;
 #endif
 
+#ifndef MIN_NP
+#define MIN_NP 128 // Default to 4kb (~1 page worth of memory)
+//#define MIN_NP 32768 // 32768 particles is 1 MiB of memory.
+#endif
+
+
 enum { MAX_PBC = 32, MAX_SP = 32 };
 
 void
@@ -353,12 +359,6 @@ boundary_p( particle_bc_t       * RESTRICT pbc_list,
         sp->pm = new_pm;
         sp->max_nm = nm;*/
       }
-
-#ifndef MIN_NP
-#define MIN_NP 128 // Default to 4kb (~1 page worth of memory)
-//#define MIN_NP 32768 // 32768 particles is 1 MiB of memory.
-#endif
-
       else if(sp->max_np > MIN_NP && n < sp->max_np>>1)
       {
         n += 0.125*n; // Overallocate by less since this rank is decreasing
@@ -379,7 +379,7 @@ boundary_p( particle_bc_t       * RESTRICT pbc_list,
         FREE_ALIGNED( sp->pm );
         sp->pm = new_pm, sp->max_nm = nm;*/
       }
-#undef MIN_NP
+
       // Feasibly, a vacuum-filled rank may receive a shock and need more movers
       // than available from MIN_NP
       nm = sp->nm + max_inj;


### PR DESCRIPTION
Dynamic resizing of particle storage is turned on and both grows and shrinks arrays.  The mover arrays are not resized, except in the unlikely case of too many incoming particles, and require adequate storage allocated during initialization.