### PR TITLE
Add extended unit support tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,12 @@ option(VPIC_PRINT_MORE_DIGITS "Print more digits in VPIC timer info" OFF)
 
 option(ENABLE_OPENSSL "Enable OpenSSL support for checksums" OFF)
 
+option(DISABLE_DYNAMIC_RESIZING "Prevent particle arrays from dynamically resizing during a run" OFF)
+
+# option to set minimum number of particles
+set(SET_MIN_NUM_PARTICLES AUTO CACHE STRING "Select minimum number of particles to use, if using dynamic particle array resizing")
+
+
 #------------------------------------------------------------------------------#
 # Create include and link aggregates
 #
@@ -96,6 +102,13 @@ endif("${CMAKE_BUILD_TYPE}" STREQUAL "RelWithDebInfo")
 string(REPLACE ";" " " string_libraries "${MPI_CXX_LIBRARIES} ${MPI_C_LIBRARIES}")
 set(VPIC_CXX_LIBRARIES "${string_libraries}")
 
+if(DISABLE_DYNAMIC_RESIZING)
+  add_definitions(-DDISABLE_DYNAMIC_RESIZING)
+endif(DISABLE_DYNAMIC_RESIZING)
+
+if(NOT SET_MIN_NUM_PARTICLES STREQUAL "AUTO")
+    add_definitions(-DMIN_NP=${SET_MIN_NUM_PARTICLES})
+endif()
 #------------------------------------------------------------------------------#
 # OpenSSL
 #------------------------------------------------------------------------------#

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,6 +118,12 @@ find_package(Threads REQUIRED)
 # Add options for building with a threading model.
 #------------------------------------------------------------------------------#
 
+# We don't want both PTHREADS and OpenMP
+if ((USE_PTHREADS) AND (USE_OPENMP))
+     message( FATAL_ERROR "Only one threading model can be selected" )
+endif()
+
+
 if(USE_PTHREADS)
   add_definitions(-DVPIC_USE_PTHREADS)
     set(VPIC_CXX_FLAGS "${VPIC_CXX_FLAGS} -DVPIC_USE_PTHREADS")

--- a/README.md
+++ b/README.md
@@ -52,14 +52,17 @@ with VPIC and Roadrunner, Journal of Physics: Conference Series 180,
 
 # Getting the Code
 
-VPIC uses nested submodules.  This requires the addition of the *--recursive*
-flag when cloning the repository:
+To checkout the VPIC source, do the following:
 
 ```bash
     git clone https://github.com/lanl/vpic.git
 ```
 
-This command will check out the VPIC source code.
+## Branches
+
+The stable release of vpic exists on `master`, the default branch.
+
+For more cutting edge features, consider using the `devel` branch.
 
 # Requirements
 
@@ -80,12 +83,6 @@ the top-level source directory:
     cd build
 ```
 
-Then call the curses version of CMake:
-
-```bash
-    ccmake ..
-```
-
 The `./arch` directory also contains various cmake scripts (including specific build options) which can help with building
 
 They can be invoked using something like:
@@ -94,15 +91,22 @@ They can be invoked using something like:
     ../arch/generic-Release
 ```
 
+After configuration, simply type: 
+
+```bash
+    make
+```
+
+Advanced users may chose to instead invoke `cmake` directly and hand select options
+
 GCC users should ensure the `-fno-strict-aliasing` compiler flag is set (as shown in `./arch/generic-gcc-sse`)
 
-After configuration, simply type 'make'.
 
 # Building an example input deck
 
 After you have successfully built VPIC, you should have an executable in
-the *bin* directory called *vpic*.  To build an executable from one of
-the sample input decks, simply run:
+the `bin` directory called `vpic` (`./bin/vpic`).  To build an executable from one of
+the sample input decks (found in `./sample`), simply run:
 
 ```bash
     ./bin/vpic input_deck
@@ -161,6 +165,47 @@ VPIC can restart from a checkpoint dump file, using the following syntax:
 ```
 
 To restart VPIC using the restart file `./restart/restart0`
+
+# Compile Time Arguments
+
+Currently, the following options are exposed at compile time for the users consideration:
+
+## Threading Model
+
+ - `USE_PTHREADS`: Use Pthreads for the threading model (default enabled)
+ - `USE_OPENMP`: Use OpenMP for the threading model
+
+## Vectorization
+
+ - `USE_V4_SSE`: Enable 4 wide (128-bit) SSE
+ - `USE_V4_AVX`: Enable 4 wide (128-bit) AVX
+ - `USE_V4_AVX2`: Enable 4 wide (128-bit) AVX2
+ - `USE_V4_ALTIVEC`: Enable 4 wide (128-bit) Altivec
+ - `USE_V4_PORTABLE`: Enable 4 wide (128-bit) portable implementation
+
+ - `USE_V8_AVX`: Enable 4 wide (256-bit) AVX
+ - `USE_V8_AVX2`: Enable 4 wide (256-bit) AVX2
+ - `USE_V8_PORTABLE`: Enable 4 wide (256-bit) portable implementation
+
+ - `USE_V16_AVX512`: Enable 4 wide (512-bit) AVX512
+ - `USE_V16_PORTABLE`: Enable 4 wide (512-bit) portable implementation
+
+If no combination of these are selected, the "reference" (read: unvectorized)
+version of the pusher will be used
+
+See example decks for how these are used together in combination.
+
+## Output 
+
+ - `VPIC_PRINT_MORE_DIGITS`: Enabled more digits in the debug timing implementation
+
+# Workflow
+
+Contributors are asked to be aware of the following workflow:
+
+1) Pull requests are accepted into `devel` upon tests passing
+2) `master` should reflect the *stable* state of the code
+3) Periodic releases will be made from `devel` into `master`
 
 # Feedback
 

--- a/deck/main.cc
+++ b/deck/main.cc
@@ -1,4 +1,4 @@
-/* 
+/*
  * Written by:
  *   Kevin J. Bowers, Ph.D.
  *   Plasma Physics Group (X-1)
@@ -10,97 +10,142 @@
 
 #include "vpic/vpic.h"
 
-/* The simulation variable is set up this way so both the checkpt
-   service and main can see it.  This allows main to find where
-   the restored objects are after a restore. */
-
+// The simulation variable is set up this way so both the checkpt
+// service and main can see it.  This allows main to find where
+// the restored objects are after a restore.
 vpic_simulation * simulation = NULL;
 
-void
-checkpt_main( vpic_simulation ** _simulation ) {
-  CHECKPT_PTR( simulation );
+
+/**
+ * @brief Function to checkout main simulation object for restarting
+ *
+ * @param _simulation Simulation object to checkpoint
+ */
+void checkpt_main(vpic_simulation** _simulation)
+{
+    CHECKPT_PTR( simulation );
 }
 
-vpic_simulation **
-restore_main( void ) {
-  RESTORE_PTR( simulation );
-  return &simulation;
+/**
+ * @brief Function to handle the recovery of the main simulation object at
+ * restart
+ *
+ * @return Returns a double pointer (**) to the simulation object
+ */
+vpic_simulation** restore_main(void)
+{
+    RESTORE_PTR( simulation );
+    return &simulation;
 }
 
-void
-checkpt( const char * fbase,
-         int tag ) {
-  char fname[256];
-  if( !fbase ) ERROR(( "NULL filename base" ));
-  sprintf( fname, "%s.%i.%i", fbase, tag, world_rank );
-  if( world_rank==0 ) log_printf( "*** Checkpointing to \"%s\"\n", fbase );
-  checkpt_objects( fname );
-}
-
-int
-main( int argc,
-      char **argv ) {
-  boot_services( &argc, &argv );
-
-  const char * fbase = strip_cmdline_string(&argc, &argv, "--restore", NULL);
-  if( fbase ) {
-
-    // We are restoring from a checkpoint.  Determine checkpt file
-    // for this process, restore all the objects in that file,
-    // wait for all other processes to finishing restoring (such
-    // that communication within reanimate functions is safe),
-    // reanimate all the objects and issue a final barrier to
-    // so that all processes come of a restore together.
-
-    if( world_rank==0 ) log_printf( "*** Restoring from \"%s\"\n", fbase );
+/**
+ * @brief Main checkpoint function to trigger a full checkpointing
+ *
+ * @param fbase File name base for dumping
+ * @param tag File tag to label what this checkpoint is (often used: time step)
+ */
+void checkpt(const char* fbase, int tag)
+{
     char fname[256];
-    sprintf( fname, "%s.%i", fbase, world_rank );
-    restore_objects( fname );
-    mp_barrier();
-    reanimate_objects();
-    mp_barrier();
+    if( !fbase ) ERROR(( "NULL filename base" ));
+    sprintf( fname, "%s.%i.%i", fbase, tag, world_rank );
+    if( world_rank==0 ) log_printf( "*** Checkpointing to \"%s\"\n", fbase );
+    checkpt_objects( fname );
+}
 
-  } else {
+/**
+ * @brief Program main which triggers a vpic run
+ *
+ * @param argc Standard arguments
+ * @param argv Standard arguments
+ *
+ * @return Application error code
+ */
+int main(int argc, char** argv)
+{
 
-    // We are initializing from scratch.
+    // Initialize underlying threads and services
+    boot_services( &argc, &argv );
 
-    if( world_rank==0 ) log_printf( "*** Initializing\n" );
-    simulation = new vpic_simulation;
-    simulation->initialize( argc, argv );
-    REGISTER_OBJECT( &simulation, checkpt_main, restore_main, NULL );
+    // TODO: this would be better if it was bool-like in nature
+    const char * fbase = strip_cmdline_string(&argc, &argv, "--restore", NULL);
 
-  }
+    // Detect if we should perform a restore as per the user request
+    if( fbase )
+    {
 
-  // Do any post init/restore simulation modifications
-  // FIXME-KJB: STRIP_CMDLINE COULD MAKE THIS CLEANER AND MORE POWERFUL.
+        // We are restoring from a checkpoint.  Determine checkpt file
+        // for this process, restore all the objects in that file,
+        // wait for all other processes to finishing restoring (such
+        // that communication within reanimate functions is safe),
+        // reanimate all the objects and issue a final barrier to
+        // so that all processes come of a restore together.
+        if( world_rank==0 ) log_printf( "*** Restoring from \"%s\"\n", fbase );
+        char fname[256];
+        sprintf( fname, "%s.%i", fbase, world_rank );
+        restore_objects( fname );
+        mp_barrier();
+        reanimate_objects();
+        mp_barrier();
 
-  fbase = strip_cmdline_string( &argc, &argv, "--modify", NULL );
-  if( fbase ) {
-    if( world_rank==0 ) log_printf( "*** Modifying from \"%s\"\n", fbase );
-    simulation->modify( fbase );  
-  }
+    }
+    else // We are initializing from scratch.
+    {
+        // Perform basic initialization
+        if( world_rank==0 )
+        {
+            log_printf( "*** Initializing\n" );
+        }
+        simulation = new vpic_simulation();
+        simulation->initialize( argc, argv );
+        REGISTER_OBJECT( &simulation, checkpt_main, restore_main, NULL );
+    }
 
-  // Advance the simulation
+    // Do any post init/restore simulation modifications
 
-  if( world_rank==0 ) log_printf( "*** Advancing\n" );
-  double elapsed = wallclock();
-  while( simulation->advance() ); 
-  elapsed = wallclock() - elapsed;
-  if( world_rank==0 ) {
-    int  s = (int)elapsed, m  = s/60, h  = m/60, d  = h/24, w = d/ 7;
-    /**/ s -= m*60,        m -= h*60, h -= d*24, d -= w*7;
-    log_printf( "*** Done (%gs / %iw:%id:%ih:%im:%is elapsed)\n",
+    // Detec if the "modify" option is passed, which allows users to change
+    // options (such as quota, num_step, etc) when restoring
+    fbase = strip_cmdline_string( &argc, &argv, "--modify", NULL );
+    if( fbase )
+    {
+        if( world_rank==0 ) log_printf( "*** Modifying from \"%s\"\n", fbase );
+        simulation->modify( fbase );
+    }
+
+    // Perform the main simulation
+    if( world_rank==0 ) log_printf( "*** Advancing\n" );
+    double elapsed = wallclock();
+
+    // Call the actual advance until it's done
+    // TODO: Can we make this into a bounded loop
+    while( simulation->advance() );
+
+    elapsed = wallclock() - elapsed;
+
+    // Report run time information on rank 0
+    if( world_rank==0 )
+    {
+        // Calculate time info
+        int  s = (int)elapsed, m  = s/60, h  = m/60, d  = h/24, w = d/ 7;
+        s -= m*60;
+        m -= h*60;
+        h -= d*24;
+        d -= w*7;
+
+        log_printf( "*** Done (%gs / %iw:%id:%ih:%im:%is elapsed)\n",
                 elapsed, w, d, h, m, s );
-  }
+    }
 
-  // Cleaning up
+    if( world_rank==0 ) log_printf( "*** Cleaning up\n" );
 
-  if( world_rank==0 ) log_printf( "*** Cleaning up\n" );
-  UNREGISTER_OBJECT( &simulation );
-  simulation->finalize();
-  delete simulation;
-  if( world_rank==0 ) log_printf( "normal exit\n" ); 
+    // Perform Clean up, including de-registering objects
+    UNREGISTER_OBJECT( &simulation );
+    simulation->finalize();
+    delete simulation;
 
-  halt_services();
-  return 0;
+    // Check everything went well
+    if( world_rank==0 ) log_printf( "normal exit\n" );
+
+    halt_services();
+    return 0;
 }

--- a/src/boundary/boundary_p.cc
+++ b/src/boundary/boundary_p.cc
@@ -3,15 +3,33 @@
 
 // If this is defined particle and mover buffers will not resize dynamically
 // (This is the common case for the users)
-#define DISABLE_DYNAMIC_RESIZING
+//#define DISABLE_DYNAMIC_RESIZING
 
 // FIXME: ARCHITECTURAL FLAW!  CUSTOM BCS AND SHARED FACES CANNOT
 // COEXIST ON THE SAME FACE!  THIS MEANS THAT CUSTOM BOUNDARYS MUST
 // REINJECT ALL ABSORBED PARTICLES IN THE SAME DOMAIN!
 
+
+// Updated by Scott V. Luedtke, XCP-6, December 6, 2018.
+// The mover array is now resized along with the particle array.  The mover
+// array is filled during advance_p and is most likely to overflow there, not
+// here.  Both arrays will now resize down as well.
+// 12/20/18: The mover array is no longer resized with the particle array, as
+// this actually uses more RAM than having static mover arrays.  The mover will
+// still size up if there are too many incoming particles, but I have not
+// encountered this.  Some hard-to-understand bit shifts have been replaced with
+// cleaner code that the compiler should have no trouble optimizing.
+// Spits out lots of warnings. TODO: Remove warnings after testing.
+
 #ifdef V4_ACCELERATION
 using namespace v4;
 #endif
+
+#ifndef MIN_NP
+#define MIN_NP 128 // Default to 4kb (~1 page worth of memory)
+//#define MIN_NP 32768 // 32768 particles is 1 MiB of memory.
+#endif
+
 
 enum { MAX_PBC = 32, MAX_SP = 32 };
 
@@ -53,9 +71,9 @@ boundary_p( particle_bc_t       * RESTRICT pbc_list,
   species_t * sp;
   int face;
 
-  // Check input args 
+  // Check input args
 
-  if( !sp_list ) return; // Nothing to do if no species 
+  if( !sp_list ) return; // Nothing to do if no species
   if( !fa || !aa || sp_list->g!=aa->g || fa->g!=aa->g )
     ERROR(( "Bad args" ));
 
@@ -92,7 +110,7 @@ boundary_p( particle_bc_t       * RESTRICT pbc_list,
     bc[face] = g->bc[f2b[face]];
     shared[face] = (bc[face]>=0) && (bc[face]<world_size) &&
                    (bc[face]!=world_rank);
-    if( shared[face] ) range[face] = g->range[bc[face]]; 
+    if( shared[face] ) range[face] = g->range[bc[face]];
   }
 
   // Begin receiving the particle counts
@@ -104,7 +122,7 @@ boundary_p( particle_bc_t       * RESTRICT pbc_list,
     }
 
   // Load the particle send and local injection buffers
-  
+
   do {
 
     particle_injector_t * RESTRICT ALIGNED(16) pi_send[6];
@@ -131,7 +149,7 @@ boundary_p( particle_bc_t       * RESTRICT pbc_list,
     // be satisfied (if the handlers conform that it).  We should be
     // more flexible though in the future (especially given above the
     // above overalloc).
-    
+
     int nm = 0; LIST_FOR_EACH( sp, sp_list ) nm += sp->nm;
 
     for( face=0; face<6; face++ )
@@ -165,7 +183,7 @@ boundary_p( particle_bc_t       * RESTRICT pbc_list,
       particle_injector_t * RESTRICT ALIGNED(16) pi;
       int i, voxel;
       int64_t nn;
-      
+
       // Note that particle movers for each species are processed in
       // reverse order.  This allows us to backfill holes in the
       // particle list created by boundary conditions and/or
@@ -182,7 +200,7 @@ boundary_p( particle_bc_t       * RESTRICT pbc_list,
         voxel >>= 3;
         p0[i].i = voxel;
         nn = neighbor[ 6*voxel + face ];
-        
+
         // Absorb
 
         if( nn==absorb_particles ) {
@@ -196,9 +214,6 @@ boundary_p( particle_bc_t       * RESTRICT pbc_list,
 
         if( ((nn>=0) & (nn< rangel)) | ((nn>rangeh) & (nn<=rangem)) ) {
           pi = &pi_send[face][n_send[face]++];
-	  // This appears to be working with the different components of position
-	  // and velocity for a single particle.  Thus, I do't think it is a
-	  // candidate for longer SIMD vector lengths without further study.
 #         ifdef V4_ACCELERATION
           copy_4x1( &pi->dx,    &p0[i].dx  );
           copy_4x1( &pi->ux,    &p0[i].ux  );
@@ -209,7 +224,7 @@ boundary_p( particle_bc_t       * RESTRICT pbc_list,
           pi->ux=p0[i].ux; pi->uy=p0[i].uy; pi->uz=p0[i].uz; pi->w=p0[i].w;
           pi->dispx = pm->dispx; pi->dispy = pm->dispy; pi->dispz = pm->dispz;
           pi->sp_id = sp_id;
-#         endif 
+#         endif
           (&pi->dx)[axis[face]] = dir[face];
           pi->i                 = nn - range[face];
           pi->sp_id             = sp_id;
@@ -249,9 +264,6 @@ boundary_p( particle_bc_t       * RESTRICT pbc_list,
       backfill:
 
         np--;
-	// This appears to be working with the different components of position
-	// and velocity for a single particle.  Thus, I do't think it is a
-	// candidate for longer SIMD vector lengths without further study.
 #       ifdef V4_ACCELERATION
         copy_4x1( &p0[i].dx, &p0[np].dx );
         copy_4x1( &p0[i].ux, &p0[np].ux );
@@ -260,7 +272,7 @@ boundary_p( particle_bc_t       * RESTRICT pbc_list,
 #       endif
 
       }
-      
+
       sp->np = np;
       sp->nm = 0;
     }
@@ -269,7 +281,7 @@ boundary_p( particle_bc_t       * RESTRICT pbc_list,
 
   // Finish exchanging particle counts and start exchanging actual
   // particles.
-  
+
   // Note: This is wasteful of communications.  A better protocol
   // would fuse the exchange of the counts with the exchange of the
   // messages.  in a slightly more complex protocol.  However, the MP
@@ -278,7 +290,7 @@ boundary_p( particle_bc_t       * RESTRICT pbc_list,
   // prohibits such (specifically, in both, you can't do the
   // equilvanet of a MPI_Getcount to determine how much data you
   // actually received.
-  
+
   for( face=0; face<6; face++ )
     if( shared[face] ) {
       *((int *)mp_send_buffer( mp, f2b[face] )) = n_send[face];
@@ -309,13 +321,13 @@ boundary_p( particle_bc_t       * RESTRICT pbc_list,
   // Resize particle storage to accomodate worst case inject
 
   do {
-    int n;
-    
+    int n, nm;
+
     // Resize each species's particle and mover storage to be large
     // enough to guarantee successful injection.  (If we broke down
     // the n_recv[face] by species before sending it, we could be
     // tighter on memory footprint here.)
-    
+
     int max_inj = n_ci;
     for( face=0; face<6; face++ )
       if( shared[face] ) max_inj += n_recv[face];
@@ -323,31 +335,73 @@ boundary_p( particle_bc_t       * RESTRICT pbc_list,
     LIST_FOR_EACH( sp, sp_list ) {
       particle_mover_t * new_pm;
       particle_t * new_p;
-      
+
       n = sp->np + max_inj;
       if( n>sp->max_np ) {
-        n = n + (n>>2) + (n>>4); // Increase by 31.25% (~<"silver
+        n += 0.3125*n; // Increase by 31.25% (~<"silver
         /**/                     // ratio") to minimize resizes (max
         /**/                     // rate that avoids excessive heap
         /**/                     // fragmentation)
+        //float resize_ratio = (float)n/sp->max_np;
         WARNING(( "Resizing local %s particle storage from %i to %i",
                   sp->name, sp->max_np, n ));
         MALLOC_ALIGNED( new_p, n, 128 );
         COPY( new_p, sp->p, sp->np );
         FREE_ALIGNED( sp->p );
         sp->p = new_p, sp->max_np = n;
-      }
-      
-      n = sp->nm + max_inj;
-      if( n>sp->max_nm ) {
-        n = n + (n>>2) + (n>>4); // See note above
+
+        /*nm = sp->max_nm * resize_ratio;
         WARNING(( "Resizing local %s mover storage from %i to %i",
-                  sp->name, sp->max_nm, n ));
-        MALLOC_ALIGNED( new_pm, n, 128 );
+                  sp->name, sp->max_nm, nm ));
+        MALLOC_ALIGNED( new_pm, nm, 128 );
         COPY( new_pm, sp->pm, sp->nm );
         FREE_ALIGNED( sp->pm );
         sp->pm = new_pm;
-        sp->max_nm = n;
+        sp->max_nm = nm;*/
+      }
+      else if(sp->max_np > MIN_NP && n < sp->max_np>>1)
+      {
+        n += 0.125*n; // Overallocate by less since this rank is decreasing
+        if (n<MIN_NP) n = MIN_NP;
+        //float resize_ratio = (float)n/sp->max_np;
+        WARNING(( "Resizing (shrinking) local %s particle storage from "
+                    "%i to %i", sp->name, sp->max_np, n));
+        MALLOC_ALIGNED( new_p, n, 128 );
+        COPY( new_p, sp->p, sp->np );
+        FREE_ALIGNED( sp->p );
+        sp->p = new_p, sp->max_np = n;
+
+        /*nm = sp->max_nm * resize_ratio;
+        WARNING(( "Resizing (shrinking) local %s mover storage from "
+                    "%i to %i", sp->name, sp->max_nm, nm));
+        MALLOC_ALIGNED( new_pm, nm, 128 );
+        COPY( new_pm, sp->pm, sp->nm );
+        FREE_ALIGNED( sp->pm );
+        sp->pm = new_pm, sp->max_nm = nm;*/
+      }
+
+      // Feasibly, a vacuum-filled rank may receive a shock and need more movers
+      // than available from MIN_NP
+      nm = sp->nm + max_inj;
+      if( nm>sp->max_nm ) {
+        nm += 0.3125*nm; // See note above
+        //float resize_ratio = (float)nm/sp->max_nm;
+        WARNING(( "This happened.  Resizing local %s mover storage from "
+                    "%i to %i based on not enough movers",
+                  sp->name, sp->max_nm, nm ));
+        MALLOC_ALIGNED( new_pm, nm, 128 );
+        COPY( new_pm, sp->pm, sp->nm );
+        FREE_ALIGNED( sp->pm );
+        sp->pm = new_pm;
+        sp->max_nm = nm;
+
+        /*n = sp->max_np * resize_ratio;
+        WARNING(( "Resizing local %s particle storage from %i to %i",
+                  sp->name, sp->max_np, n ));
+        MALLOC_ALIGNED( new_p, n, 128 );
+        COPY( new_p, sp->p, sp->np );
+        FREE_ALIGNED( sp->p );
+        sp->p = new_p, sp->max_np = n;*/
       }
     }
   } while(0);
@@ -368,7 +422,7 @@ boundary_p( particle_bc_t       * RESTRICT pbc_list,
     int sp_max_nm[64], n_dropped_movers[64];
 #   endif
 
-    if( num_species( sp_list ) > MAX_SP ) 
+    if( num_species( sp_list ) > MAX_SP )
       ERROR(( "Update this to support more species" ));
     LIST_FOR_EACH( sp, sp_list ) {
       sp_p[  sp->id ] = sp->p;
@@ -391,7 +445,7 @@ boundary_p( particle_bc_t       * RESTRICT pbc_list,
       /**/  particle_mover_t    * RESTRICT ALIGNED(16) pm;
       const particle_injector_t * RESTRICT ALIGNED(16) pi;
       int np, nm, n, id;
-  
+
       face++; if( face==7 ) face = 0;
       if( face==6 ) pi = ci, n = n_ci;
       else if( shared[face] ) {
@@ -400,7 +454,7 @@ boundary_p( particle_bc_t       * RESTRICT pbc_list,
           (((char *)mp_recv_buffer(mp,f2b[face]))+16);
         n  = n_recv[face];
       } else continue;
-        
+
       // Reverse order injection is done to reduce thrashing of the
       // particle list (particles are removed reverse order so the
       // overall impact of removal + injection is to keep injected
@@ -408,7 +462,7 @@ boundary_p( particle_bc_t       * RESTRICT pbc_list,
       //
       // WARNING: THIS TRUSTS THAT THE INJECTORS (INCLUDING THOSE
       // RECEIVED FROM OTHER NODES) HAVE VALID PARTICLE IDS.
-  
+
       pi += n-1;
       for( ; n; pi--, n-- ) {
         id = pi->sp_id;
@@ -418,9 +472,6 @@ boundary_p( particle_bc_t       * RESTRICT pbc_list,
 #       ifdef DISABLE_DYNAMIC_RESIZING
         if( np>=sp_max_np[id] ) { n_dropped_particles[id]++; continue; }
 #       endif
-	// This appears to be working with the different components of position
-	// and velocity for a single particle.  Thus, I do't think it is a
-	// candidate for longer SIMD vector lengths without further study.
 #       ifdef V4_ACCELERATION
         copy_4x1(  &p[np].dx,    &pi->dx    );
         copy_4x1(  &p[np].ux,    &pi->ux    );
@@ -433,9 +484,6 @@ boundary_p( particle_bc_t       * RESTRICT pbc_list,
 #       ifdef DISABLE_DYNAMIC_RESIZING
         if( nm>=sp_max_nm[id] ) { n_dropped_movers[id]++;    continue; }
 #       endif
-	// This appears to be working with the different components of position
-	// and velocity for a single particle.  Thus, I do't think it is a
-	// candidate for longer SIMD vector lengths without further study.
 #       ifdef V4_ACCELERATION
         copy_4x1( &pm[nm].dispx, &pi->dispx );
         pm[nm].i = np;
@@ -446,7 +494,7 @@ boundary_p( particle_bc_t       * RESTRICT pbc_list,
         sp_nm[id] = nm + move_p( p, pm+nm, a0, g, sp_q[id] );
       }
     } while(face!=5);
-  
+
     LIST_FOR_EACH( sp, sp_list ) {
 #     ifdef DISABLE_DYNAMIC_RESIZING
       if( n_dropped_particles[sp->id] )
@@ -466,7 +514,7 @@ boundary_p( particle_bc_t       * RESTRICT pbc_list,
     }
 
   } while(0);
-  
+
   for( face=0; face<6; face++ )
     if( shared[face] ) mp_end_send(mp,f2b[face]);
 }

--- a/src/util/checkpt/checkpt.c
+++ b/src/util/checkpt/checkpt.c
@@ -165,11 +165,17 @@ object_ptr( size_t id ) {
   return node ? node->obj : NULL;
 }
 
-void
-register_object( void * obj,
-                 checkpt_func_t checkpt_func,
-                 restore_func_t restore_func,
-                 reanimate_func_t reanimate_func ) {
+// TODO: It's common to pass a ** in here, can we change the interface to just
+// be a regular pointer? I think we should avoid void casts where possible..
+// (but I accept checkpoint could possibly be re-written)
+void register_object(
+        void* obj,
+        checkpt_func_t checkpt_func,
+        restore_func_t restore_func,
+        reanimate_func_t reanimate_func
+)
+{
+
   registry_t * node, * prev;
 
   /* Check input args */

--- a/src/util/util_base.c
+++ b/src/util/util_base.c
@@ -97,7 +97,7 @@ void detect_old_style_arguments(int* pargc, char *** pargv)
       prefix_keys[0] = "-tpp";
       prefix_keys[1] = "-restore";
 
-      match_keys[0] = "restart";
+      match_keys[0] = "-restart";
 
       char* arg = (*pargv)[i];
 


### PR DESCRIPTION
This PR does a few major things:

1) demonstrates how to write a unit test without doing a full input deck read/build cycle
2) Significantly increases code coverage from the tests
3) Takes a first step is adding a test for good "physics correctness" by trying to match against the energies from GY's IVPIC Weibel deck