### PR TITLE
update build system so CPP defines get seen by the input deck buildin…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -298,6 +298,13 @@ endif(ENABLE_COVERAGE_BUILD)
 configure_file(${CMAKE_SOURCE_DIR}/sample/Makefile.run.in
   ${CMAKE_BINARY_DIR}/bin/Makefile.run)
 
+# Append all defines to VPIC_DEFINES, so it can be seen during input deck building
+get_directory_property(ALL_DEFINES DIRECTORY ${CMAKE_SOURCE_DIR} COMPILE_DEFINITIONS)
+#string(REPLACE ";" " -D" EEK "${ALL_DEFINES}")
+foreach(d ${ALL_DEFINES})
+    set(VPIC_DEFINES "${VPIC_DEFINES} -D${d}")
+endforeach()
+
 # install script
 configure_file(${CMAKE_SOURCE_DIR}/bin/vpic.in
   ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/vpic-install)

--- a/bin/vpic.in
+++ b/bin/vpic.in
@@ -2,6 +2,6 @@
 
 deck=`echo $1 | sed 's,\.cxx,,g;s,\.cc,,g;s,\.cpp,,g;s,.*\/,,g'`
 
-echo "${CMAKE_CXX_COMPILER} ${CMAKE_CXX_FLAGS} -I. -I${CMAKE_INSTALL_PREFIX}/include/vpic -DINPUT_DECK=$1 ${CMAKE_INSTALL_PREFIX}/share/vpic/main.cc ${CMAKE_INSTALL_PREFIX}/share/vpic/wrapper.cc -o $deck.${CMAKE_SYSTEM_NAME} -Wl,-rpath,${CMAKE_INSTALL_PREFIX}/lib -L${CMAKE_INSTALL_PREFIX}/lib -lvpic ${VPIC_CXX_LIBRARIES} -lpthread -ldl"
+echo "${CMAKE_CXX_COMPILER} ${VPIC_DEFINES} ${CMAKE_CXX_FLAGS} -I. -I${CMAKE_INSTALL_PREFIX}/include/vpic -DINPUT_DECK=$1 ${CMAKE_INSTALL_PREFIX}/share/vpic/main.cc ${CMAKE_INSTALL_PREFIX}/share/vpic/wrapper.cc -o $deck.${CMAKE_SYSTEM_NAME} -Wl,-rpath,${CMAKE_INSTALL_PREFIX}/lib -L${CMAKE_INSTALL_PREFIX}/lib -lvpic ${VPIC_CXX_LIBRARIES} -lpthread -ldl"
 
-${CMAKE_CXX_COMPILER} ${CMAKE_CXX_FLAGS} -I. -I${CMAKE_INSTALL_PREFIX}/include/vpic -DINPUT_DECK=$1 ${CMAKE_INSTALL_PREFIX}/share/vpic/main.cc ${CMAKE_INSTALL_PREFIX}/share/vpic/wrapper.cc -o $deck.${CMAKE_SYSTEM_NAME} -Wl,-rpath,${CMAKE_INSTALL_PREFIX}/lib -L${CMAKE_INSTALL_PREFIX}/lib -lvpic ${VPIC_CXX_LIBRARIES} -lpthread -ldl
+${CMAKE_CXX_COMPILER} ${VPIC_DEFINES} ${CMAKE_CXX_FLAGS} -I. -I${CMAKE_INSTALL_PREFIX}/include/vpic -DINPUT_DECK=$1 ${CMAKE_INSTALL_PREFIX}/share/vpic/main.cc ${CMAKE_INSTALL_PREFIX}/share/vpic/wrapper.cc -o $deck.${CMAKE_SYSTEM_NAME} -Wl,-rpath,${CMAKE_INSTALL_PREFIX}/lib -L${CMAKE_INSTALL_PREFIX}/lib -lvpic ${VPIC_CXX_LIBRARIES} -lpthread -ldl


### PR DESCRIPTION
…g phase. This is important as the two stages may see different versions of header files without this