### PR TITLE
fix vpic "make install"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,13 @@ cmake_minimum_required(VERSION 3.1)
 project(vpic)
 
 #------------------------------------------------------------------------------#
+# Quiet newer versions of cmake about MPI_ROOT
+#------------------------------------------------------------------------------#
+if(POLICY CMP0074)
+    cmake_policy(SET CMP0074 NEW)
+endif()
+
+#------------------------------------------------------------------------------#
 # If a C++11 compiler is available, then set the appropriate flags
 #------------------------------------------------------------------------------#
 
@@ -312,10 +319,11 @@ install(FILES ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/vpic-install
     WORLD_READ WORLD_EXECUTE
     )
 
-install(FILES ${CMAKE_SOURCE_DIR}/deck/main.cc
-  DESTINATION share/vpic)
-install(FILES ${CMAKE_SOURCE_DIR}/deck/wrapper.cc
-  DESTINATION share/vpic)
+install(FILES deck/main.cc deck/wrapper.cc DESTINATION share/vpic)
+install(FILES deck/wrapper.h DESTINATION include/vpic)
+install(DIRECTORY src/ DESTINATION include/vpic
+         FILES_MATCHING PATTERN "*.h")
+
 
 # local script
 configure_file(${CMAKE_SOURCE_DIR}/bin/vpic-local.in

--- a/bin/vpic.in
+++ b/bin/vpic.in
@@ -2,6 +2,6 @@
 
 deck=`echo $1 | sed 's,\.cxx,,g;s,\.cc,,g;s,\.cpp,,g;s,.*\/,,g'`
 
-echo "${CMAKE_CXX_COMPILER} ${CMAKE_CXX_FLAGS} -I. -I${CMAKE_INSTALL_PREFIX}/include/vpic -DINPUT_DECK=$1 ${CMAKE_INSTALL_PREFIX}/share/vpic/main.cc ${CMAKE_INSTALL_PREFIX}/share/vpic/wrapper.cc -o $deck.${CMAKE_SYSTEM_NAME} -Wl,-rpath,${CMAKE_INSTALL_PREFIX}/lib -L${CMAKE_INSTALL_PREFIX}/lib -lvpic ${VPIC_CXX_LIBRARIES} -lpthread -ldl"
+echo "${CMAKE_CXX_COMPILER} ${CMAKE_CXX_FLAGS} -I. -I${CMAKE_INSTALL_PREFIX}/include/vpic ${VPIC_CXX_FLAGS} -DINPUT_DECK=$1 ${CMAKE_INSTALL_PREFIX}/share/vpic/main.cc ${CMAKE_INSTALL_PREFIX}/share/vpic/wrapper.cc -o $deck.${CMAKE_SYSTEM_NAME} -Wl,-rpath,${CMAKE_INSTALL_PREFIX}/lib -L${CMAKE_INSTALL_PREFIX}/lib -lvpic ${VPIC_CXX_LIBRARIES} -lpthread -ldl"
 
-${CMAKE_CXX_COMPILER} ${CMAKE_CXX_FLAGS} -I. -I${CMAKE_INSTALL_PREFIX}/include/vpic -DINPUT_DECK=$1 ${CMAKE_INSTALL_PREFIX}/share/vpic/main.cc ${CMAKE_INSTALL_PREFIX}/share/vpic/wrapper.cc -o $deck.${CMAKE_SYSTEM_NAME} -Wl,-rpath,${CMAKE_INSTALL_PREFIX}/lib -L${CMAKE_INSTALL_PREFIX}/lib -lvpic ${VPIC_CXX_LIBRARIES} -lpthread -ldl
+${CMAKE_CXX_COMPILER} ${CMAKE_CXX_FLAGS} -I. -I${CMAKE_INSTALL_PREFIX}/include/vpic ${VPIC_CXX_FLAGS} -DINPUT_DECK=$1 ${CMAKE_INSTALL_PREFIX}/share/vpic/main.cc ${CMAKE_INSTALL_PREFIX}/share/vpic/wrapper.cc -o $deck.${CMAKE_SYSTEM_NAME} -Wl,-rpath,${CMAKE_INSTALL_PREFIX}/lib -L${CMAKE_INSTALL_PREFIX}/lib -lvpic ${VPIC_CXX_LIBRARIES} -lpthread -ldl


### PR DESCRIPTION
* vpic.in (for the install directory) needs ${VPIC_CXX_FLAGS} on cmd line
    
* add cmake install() calls necessary to install all required files
       in ${CMAKE_INSTALL_PREFIX} so that vpic can be run from the install
       directory (wrapper.h and include files were not being installed)
    
* also, quiet newer versions of cmake from complaining about MPI_ROOT
       at config time by setting cmake policy CMP0074 to "NEW"

