### PR TITLE
fix vpic "make install"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,13 @@ cmake_minimum_required(VERSION 3.1)
 project(vpic)
 
 #------------------------------------------------------------------------------#
+# Quiet newer versions of cmake about MPI_ROOT
+#------------------------------------------------------------------------------#
+if(POLICY CMP0074)
+    cmake_policy(SET CMP0074 NEW)
+endif()
+
+#------------------------------------------------------------------------------#
 # If a C++11 compiler is available, then set the appropriate flags
 #------------------------------------------------------------------------------#
 
@@ -325,10 +332,11 @@ install(FILES ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/vpic-install
     WORLD_READ WORLD_EXECUTE
     )
 
-install(FILES ${CMAKE_SOURCE_DIR}/deck/main.cc
-  DESTINATION share/vpic)
-install(FILES ${CMAKE_SOURCE_DIR}/deck/wrapper.cc
-  DESTINATION share/vpic)
+install(FILES deck/main.cc deck/wrapper.cc DESTINATION share/vpic)
+install(FILES deck/wrapper.h DESTINATION include/vpic)
+install(DIRECTORY src/ DESTINATION include/vpic
+         FILES_MATCHING PATTERN "*.h")
+
 
 # local script
 configure_file(${CMAKE_SOURCE_DIR}/bin/vpic-local.in


### PR DESCRIPTION
*  add cmake install() calls necessary to install all required files
  in ${CMAKE_INSTALL_PREFIX} so that vpic can be run from the install
  directory (wrapper.h and include files were not being installed)

* also, quiet newer versions of cmake from complaining about MPI_ROOT
  at config time by setting cmake policy CMP0074 to "NEW"

confirmed that a VPIC_CXX_FLAGS fix for vpic.in is not necessary in devel branch, so it
is not included here.
 