### PR TITLE
support vpic config using a cmake cache file

### DIFF
--- a/arch/cmake-fns.sh
+++ b/arch/cmake-fns.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2019 Carnegie Mellon University,
+# Copyright (c) 2019 Triad National Security, LLC, as operator of
+#     Los Alamos National Laboratory.
+#
+# All rights reserved.
+#
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file. See the AUTHORS file for names of contributors.
+#
+
+#
+# cmake-fns.sh  cmake helper functions
+# 18-Jul-2019  chuck@ece.cmu.edu
+#
+
+#
+# create_cmake_cache: create a new cmake cache
+#
+create_cmake_cache() {
+    init_cache=./vpic-init-cache.cmake
+    rm -f $init_cache
+    touch $init_cache
+    if [ ! -w $init_cache ]; then
+        echo "ERROR: failed to create $init_cache init cache"
+        exit 1
+    fi
+}
+
+#
+# set_cache_bool: add a bool to the current cache
+#
+set_cache_bool() {
+  echo "set($1 \"$2\" CACHE BOOL \"Initial cache\" FORCE)" >> $init_cache
+}
+
+#
+# set_cache_string: add a string to the current cache
+#
+set_cache_string() {
+  echo "set($1 \"$2\" CACHE STRING \"Initial cache\" FORCE)" >> $init_cache
+}

--- a/arch/gcc/reference-Release
+++ b/arch/gcc/reference-Release
@@ -1,22 +1,38 @@
 #! /usr/bin/env bash
 #------------------------------------------------------------------------------#
 # Get the path to the project from which this script was called
+# and init the cmake variable cache with the desired values.
 #------------------------------------------------------------------------------#
 
 src_dir="${0%/*}/../.."
+. ${src_dir}/arch/cmake-fns.sh      # load helper functions
 
 #------------------------------------------------------------------------------#
-# Call CMake command
+# establish cache values for this config
 #------------------------------------------------------------------------------#
-
 # The flag -rdynamic removes warnings of the form:
 # Unable to find a safely writable symbol that corresponds to address 432af0
 # (the closest match was "(null)" from "./lpi_2d_F6_test.Linux").  Writing out
 # the raw address instead and keeping my fingers crossed.
 
-cmake \
-  -DCMAKE_BUILD_TYPE=Release \
-  -DENABLE_INTEGRATED_TESTS=ON \
-  -DCMAKE_C_FLAGS="-rdynamic -fno-strict-aliasing" \
-  -DCMAKE_CXX_FLAGS="-rdynamic -fno-strict-aliasing" \
-  $src_dir
+create_cmake_cache
+set_cache_string   CMAKE_BUILD_TYPE        Release
+set_cache_bool     ENABLE_INTEGRATED_TESTS ON
+set_cache_string   CMAKE_C_FLAGS           "-rdynamic -fno-strict-aliasing"
+set_cache_string   CMAKE_CXX_FLAGS         "-rdynamic -fno-strict-aliasing"
+
+# allow user to skip running cmake.
+if [ x$1 = xinitcache ]; then
+    echo ${init_cache} created.
+    echo Now you can run \"cmake -C ${init_cache} src_dir\" to configure.
+    exit 0
+fi
+
+#------------------------------------------------------------------------------#
+# Call CMake command
+#------------------------------------------------------------------------------#
+cmake -C $init_cache $src_dir
+
+if [ $? = 0 ]; then
+    echo Now you can run \"make\" to build VPIC.
+fi

--- a/arch/gcc/v4-sse
+++ b/arch/gcc/v4-sse
@@ -1,23 +1,39 @@
 #! /usr/bin/env bash
 #------------------------------------------------------------------------------#
 # Get the path to the project from which this script was called
+# and init the cmake variable cache with the desired values.
 #------------------------------------------------------------------------------#
 
 src_dir="${0%/*}/../.."
+. ${src_dir}/arch/cmake-fns.sh      # load helper functions
 
 #------------------------------------------------------------------------------#
-# Call CMake command
+# establish cache values for this config
 #------------------------------------------------------------------------------#
-
 # The flag -rdynamic removes warnings of the form:
 # Unable to find a safely writable symbol that corresponds to address 432af0
 # (the closest match was "(null)" from "./lpi_2d_F6_test.Linux").  Writing out
 # the raw address instead and keeping my fingers crossed.
 
-cmake \
-  -DCMAKE_BUILD_TYPE=Release \
-  -DENABLE_INTEGRATED_TESTS=ON \
-  -DUSE_V4_SSE=ON \
-  -DCMAKE_C_FLAGS="-rdynamic -fno-strict-aliasing" \
-  -DCMAKE_CXX_FLAGS="-rdynamic -fno-strict-aliasing" \
-  $src_dir
+create_cmake_cache
+set_cache_string   CMAKE_BUILD_TYPE        Release
+set_cache_bool     ENABLE_INTEGRATED_TESTS ON
+set_cache_bool     USE_V4_SSE              ON
+set_cache_string   CMAKE_C_FLAGS           "-rdynamic -fno-strict-aliasing"
+set_cache_string   CMAKE_CXX_FLAGS         "-rdynamic -fno-strict-aliasing"
+
+# allow user to skip running cmake.
+if [ x$1 = xinitcache ]; then
+    echo ${init_cache} created.
+    echo Now you can run \"cmake -C ${init_cache} src_dir\" to configure.
+    exit 0
+fi
+
+#------------------------------------------------------------------------------#
+# Call CMake command
+#------------------------------------------------------------------------------#
+cmake -C $init_cache $src_dir
+
+if [ $? = 0 ]; then
+    echo Now you can run \"make\" to build VPIC.
+fi

--- a/arch/gcc/v8-avx2
+++ b/arch/gcc/v8-avx2
@@ -1,24 +1,40 @@
 #! /usr/bin/env bash
 #------------------------------------------------------------------------------#
 # Get the path to the project from which this script was called
+# and init the cmake variable cache with the desired values.
 #------------------------------------------------------------------------------#
 
 src_dir="${0%/*}/../.."
+. ${src_dir}/arch/cmake-fns.sh      # load helper functions
 
 #------------------------------------------------------------------------------#
-# Call CMake command
+# establish cache values for this config
 #------------------------------------------------------------------------------#
-
 # The flag -rdynamic removes warnings of the form:
 # Unable to find a safely writable symbol that corresponds to address 432af0
 # (the closest match was "(null)" from "./lpi_2d_F6_test.Linux").  Writing out
 # the raw address instead and keeping my fingers crossed.
 
-cmake \
-  -DCMAKE_BUILD_TYPE=Release \
-  -DENABLE_INTEGRATED_TESTS=ON \
-  -DUSE_V4_AVX2=ON \
-  -DUSE_V8_AVX2=ON \
-  -DCMAKE_C_FLAGS="-rdynamic -fno-strict-aliasing" \
-  -DCMAKE_CXX_FLAGS="-rdynamic -fno-strict-aliasing" \
-  $src_dir
+create_cmake_cache
+set_cache_string   CMAKE_BUILD_TYPE        Release
+set_cache_bool     ENABLE_INTEGRATED_TESTS ON
+set_cache_bool     USE_V4_AVX2             ON
+set_cache_bool     USE_V8_AVX2             ON
+set_cache_string   CMAKE_C_FLAGS           "-rdynamic -fno-strict-aliasing"
+set_cache_string   CMAKE_CXX_FLAGS         "-rdynamic -fno-strict-aliasing"
+
+# allow user to skip running cmake.
+if [ x$1 = xinitcache ]; then
+    echo ${init_cache} created.
+    echo Now you can run \"cmake -C ${init_cache} src_dir\" to configure.
+    exit 0
+fi
+
+#------------------------------------------------------------------------------#
+# Call CMake command
+#------------------------------------------------------------------------------#
+cmake -C $init_cache $src_dir
+
+if [ $? = 0 ]; then
+    echo Now you can run \"make\" to build VPIC.
+fi

--- a/arch/lanl-current-mods
+++ b/arch/lanl-current-mods
@@ -1,0 +1,841 @@
+#!/usr/bin/env bash
+#------------------------------------------------------------------------------#
+# This script supports building VPIC on Los Alamos National Laboratory (LANL)
+# clusters based on the current set of loaded modules.  Select the compiler,
+# MPI, processor type, etc. by using "module load" and then run this script
+# to generate an appropriate set of cmake cache variables that can be loaded
+# with the "-C" flag of cmake.
+#
+# Normal users should not need to change this script if they are building VPIC
+# and are happy with the current loaded set of modules and the defaults
+# in this script.
+#------------------------------------------------------------------------------#
+#     XXX: TODO - fix handling of compiler opt flags (build type)
+#               - review interaction between cache and external cmake runs
+#               - get cmake to do more of the work?
+
+#------------------------------------------------------------------------------#
+# Get the path to the project from which this script was called.
+#------------------------------------------------------------------------------#
+
+src_dir="${0%/*}/.."
+. ${src_dir}/arch/cmake-fns.sh      # load helper functions
+
+#------------------------------------------------------------------------------#
+# Configure the type of build that we want to perform.
+#------------------------------------------------------------------------------#
+
+#------------------------------------------------------------------------------#
+# select the compiler (VCOM) and MPI (VMPI) using module-fns.sh.
+# module-fns.sh uses the current loaded set of modules.
+#------------------------------------------------------------------------------#
+. ${src_dir}/arch/module-fns.sh
+
+#------------------------------------------------------------------------------#
+# Choose a thread model.
+#------------------------------------------------------------------------------#
+# One of the two available thread models must be chosen. Valid options are the
+# following.
+#
+# PTH: Pthreads
+# OMP: OpenMP
+#------------------------------------------------------------------------------#
+
+VTHR="PTH"
+#VTHR="OMP"
+
+#------------------------------------------------------------------------------#
+# Choose type of vector intrinsics support.
+#------------------------------------------------------------------------------#
+# Note the following constraints.
+#
+# Each of the nine variables in this section must have a configured value.
+# This is because the corresponding "USE" cmake variable is set on the cmake
+# command line below to allow any possible combinations to be configured using
+# a single cmake command.
+#
+# If all values are configured as OFF, the scalar implementations of VPIC
+# functions which are not vectorized will be used.
+#
+# It is possible to have a vector version configured as ON for each of the
+# three vector widths i.e. V4, V8 and V16. In that scenario, if a given VPIC
+# function has a V16 implementation, that will be used. If there is not a V16
+# implementation but there is a V8 implementation, that will be used. If there
+# is not a V16 or V8 implementation but there is a V4 implementation, that
+# will be used. Finally, for functions that have no vector implementations,
+# the scalar version will be used.
+#
+# Currently, it is recommended to always configure the appropriate V4 version
+# as on if using vector versions because there are key functions that only
+# have a V4 version because the current algorithm does not generalize to
+# longer vector lengths. An example is the move_p function. Since the V4
+# versions are generally more performant than the scalar versions, it makes
+# sense to use them even when using the longer vector length implementations
+# for other VPIC functions.
+#
+# In summary, when using vector versions on a machine with 256 bit SIMD, the
+# V4 and V8 implementations should be configured as ON. When using a machine
+# with 512 bit SIMD, V4 and V16 implementations should be configured as ON.
+#
+# First, we turn all of the vector options OFF. Then, we turn on the ones we
+# want.
+#------------------------------------------------------------------------------#
+
+SET_V4_PORTABLE="OFF"
+SET_V4_SSE="OFF"
+SET_V4_AVX="OFF"
+SET_V4_AVX2="OFF"
+SET_V8_PORTABLE="OFF"
+SET_V8_AVX="OFF"
+SET_V8_AVX2="OFF"
+SET_V16_PORTABLE="OFF"
+SET_V16_AVX512="OFF"
+
+if [ x$VCPU = xhaswell ]; then
+    SET_V4_AVX2="ON"
+    SET_V8_AVX2="ON"
+elif [ x$VCPU = xknl ]; then
+    SET_V4_AVX2="ON"
+    SET_V16_AVX512="ON"
+elif [ x$VCPU = xbroadwell ]; then
+    SET_V4_AVX2="ON"
+    SET_V8_AVX2="ON"
+else
+    echo "WARNING: unknown VCPU $VCPU - using scalar vector default."
+fi
+
+#------------------------------------------------------------------------------#
+# Choose format of status update output.
+#------------------------------------------------------------------------------#
+# One of the two available options must be chosen. Valid options are ON and
+# OFF.
+#
+# If SET_MORE_DIGITS=OFF, the output has two significant figures.
+#
+# If SET_MORE_DIGITS=ON, the output has four significant figures.
+#------------------------------------------------------------------------------#
+
+SET_MORE_DIGITS="OFF"
+#SET_MORE_DIGITS="ON"
+
+#------------------------------------------------------------------------------#
+# Choose a particle sort implementation.
+#------------------------------------------------------------------------------#
+# One of the two available options must be chosen. Valid options are the
+# following.
+#
+# LSORT: legacy, thread serial sort
+# TSORT: thread parallel sort
+#
+# The LSORT particle sort implementation is the thread serial particle sort
+# implementation from the legacy v407 version of VPIC. This implementation
+# supports both in-place and out-of-place sorting of the particles. It is very
+# competitive with the thread parallel sort implementation for a small number
+# of threads per MPI rank, i.e. 4 or less, especially on KNL because sorting
+# the particles in-place allows the fraction of particles stored in High
+# Bandwidth Memory (HBM) to remain stored in HBM. Also, the memory footprint
+# of VPIC is reduced by the memory of a particle array which can be significant
+# for particle dominated problems.
+#
+# The TSORT particle sort implementation is a thread parallel implementation.
+# Currently, it can only perform out-of-place sorting of the particles. It will
+# be more performant than the LSORT implementation when using many threads per
+# MPI rank but uses more memory because of the out-of-place sort.
+#------------------------------------------------------------------------------#
+
+VSORT="LSORT"
+#VSORT="TSORT"
+
+#------------------------------------------------------------------------------#
+# Choose type of library to build.
+#------------------------------------------------------------------------------#
+# One of the two available options must be chosen. Valid options are ON or OFF.
+#
+# The default is to build a static library, i.e. OFF.
+#------------------------------------------------------------------------------#
+
+SET_SHARED_LIBS="OFF"
+#SET_SHARED_LIBS="ON"
+
+#------------------------------------------------------------------------------#
+# Choose integrated test support.
+#------------------------------------------------------------------------------#
+# One of the two available options must be chosen. Valid options are ON or OFF.
+#
+# The default is not to build the integrated tests, i.e. OFF.
+#------------------------------------------------------------------------------#
+
+SET_INTEGRATED_TESTS="OFF"
+#SET_INTEGRATED_TESTS="ON"
+
+#------------------------------------------------------------------------------#
+# Choose unit test support.
+#------------------------------------------------------------------------------#
+# One of the two available options must be chosen. Valid options are ON or OFF.
+#
+# The default is not to build the unit tests, i.e. OFF.
+#------------------------------------------------------------------------------#
+
+SET_UNIT_TESTS="OFF"
+#SET_UNIT_TESTS="ON"
+
+#------------------------------------------------------------------------------#
+# Choose OpenSSL support for checksums.
+#------------------------------------------------------------------------------#
+# One of the two available options must be chosen. Valid options are ON and
+# OFF.
+#
+# If SET_ENABLE_OPENSSL=OFF, use of checksums is turned off.
+#
+# If SET_ENABLE_OPENSSL=ON, use of checksums is turned on.
+#------------------------------------------------------------------------------#
+
+SET_ENABLE_OPENSSL="OFF"
+#SET_ENABLE_OPENSSL="ON"
+
+#------------------------------------------------------------------------------#
+# Choose support for dynamic resizing of particle arrays.
+#------------------------------------------------------------------------------#
+# One of the two available options must be chosen. Valid options are ON and
+# OFF.
+#
+# If SET_DISABLE_DYNAMIC_RESIZING=OFF, particle arrays will be resized
+# dynamically.
+#
+# If SET_DISABLE_DYNAMIC_RESIZING=ON, particle arrays will not be resized
+# dynamically and the user will be responsible for ensuring that particle
+# arrays have enough space to handle the evolution of a non-uniform particle
+# distribution.
+#------------------------------------------------------------------------------#
+
+SET_DISABLE_DYNAMIC_RESIZING="OFF"
+#SET_DISABLE_DYNAMIC_RESIZING="ON"
+
+#------------------------------------------------------------------------------#
+# Choose the minimum number of particles to dynamically allocate space for.
+#------------------------------------------------------------------------------#
+# A value must be chosen.  The default is 128 particles which allocates space
+# equal to a 4 KByte page size.
+#------------------------------------------------------------------------------#
+
+SET_PARTICLE_MIN_NUM="128"
+#SET_PARTICLE_MIN_NUM="32768"
+
+#------------------------------------------------------------------------------#
+# Choose the CMake build type.
+#------------------------------------------------------------------------------#
+# One of the available options must be chosen. Valid options depend on build
+# types available in the CMake version but include at least the following.
+#
+# Release: In general, the default for CMake.
+# None: Tells CMake not to use any pre-defined build type and gives VPIC build
+#       system total control of CMake variables defined on cmake command line.
+#------------------------------------------------------------------------------#
+
+SET_BUILD_TYPE="Release"
+#SET_BUILD_TYPE="None"
+
+#------------------------------------------------------------------------------#
+# Unless the user wants to modify options to the compiler, no changes should
+# be needed below this point.
+#
+# If the user desires to configure compiler options, proceed to the section
+# below for the chosen compiler.
+#------------------------------------------------------------------------------#
+
+#------------------------------------------------------------------------------#
+# Configure default compiler names to use
+#------------------------------------------------------------------------------#
+
+if [ x$craype = x1 ]; then             # let cray wrappers select compiler
+    VPIC_COMPILER_C="cc"
+    VPIC_COMPILER_CXX="CC"
+elif [ x$VMPI = xIMPI -a x$VCOM = xINT ]; then
+    #
+    # XXX: on gr-fe IPMI mpicc is a wrapper script that defaults to gcc.
+    # it also has mpigcc and mpiicc that direct to GNU and INT, respectively.
+    # if you want INT with IMPI you have to direct compiles IMPI to icc using
+    # one of:
+    #   - '-cc=icc' to the mpicc wrapper script
+    #   - environment variables, the mpicc script does this:
+    #     compiler_name=${I_MPI_CC:-${MPICH_CC:-${default_compiler_name:?}}}
+    #   - just set the compiler directly to mpiicc  (this is what we do)
+    #
+    # on the crays, the cray wrapper takes care of this for us.
+    #
+    # XXX: in theory, cmake should be able to figure out what to do without
+    #      having to set VPIC_COMPILER_{C,CXX} based on the mpi in the path.
+    #      note: VPIC_COMPILER_{C,CXX} sets CMAKE_{C,CXX}_COMPILER
+    #
+    # XXX: but still need the C=cc CXX=CC on lanl cray, as the PrgEnv-intel
+    #      sets $CC to point directly to the intel compiler instead of
+    #      at the cray wrapper (why?)
+    #
+    VPIC_COMPILER_C="mpiicc"
+    VPIC_COMPILER_CXX="mpiicpc"
+else
+    VPIC_COMPILER_C="mpicc"
+    VPIC_COMPILER_CXX="mpicxx"
+fi
+
+#------------------------------------------------------------------------------#
+# Configure options for the Intel compilers.
+#------------------------------------------------------------------------------#
+
+if [ "$VCOM" = "INT" ]
+then
+    #--------------------------------------------------------------------------#
+    # Use "-g" to provide debug symbols in the executable.  In general, use of
+    # "-g" with modern compilers does not degrade performance and provides
+    # information required by many tools such as debugging and performance
+    # analysis tools.
+    #
+    # Use of "-O3" provides fairly aggressive optimization. When using vector
+    # intrinsics versions, most of the optimization is explicit in the
+    # intrinsics implementations. Reasonable alternatives to "-O3" could be
+    # "-O2" or "-Ofast". These alternatives should be benchmarked sometime.
+    #--------------------------------------------------------------------------#
+
+    FLAGS_CXX_COMPILER="-g -O3"
+
+    #--------------------------------------------------------------------------#
+    # Use of "-inline-forceinline" overrides default heuristics of compiler
+    # and forces inlining of functions marked with inline keyword if compiler
+    # is able to inline. For VPIC, this option has mainly been used when using
+    # a portable implementation to force inlining by compiler and also when
+    # use of "-Winline" option identifies functions not being inlined that are
+    # marked with inline keyword.
+    #
+    # Use of "-qoverride-limits" cause certain internal compiler limits to be
+    # ignored that are used to limit memory usage and excessive compile times
+    # by the compiler.
+    #
+    # Use of "-vec-threshold0" ignores compiler heuristics and causes loops
+    # which can be vectorized to always be vectorized, regardless of the
+    # amount of computational work in the loop.
+    #--------------------------------------------------------------------------#
+
+    FLAGS_CXX_COMPILER+=" -inline-forceinline"
+    #FLAGS_CXX_COMPILER+=" -vec-threshold0"
+    FLAGS_CXX_COMPILER+=" -qoverride-limits"
+
+    #--------------------------------------------------------------------------#
+    # Use of "-no-ansi-alias" informs compiler that VPIC does not obey ANSI
+    # aliasing rules which can reduce available optimizations.
+    #--------------------------------------------------------------------------#
+
+    FLAGS_CXX_COMPILER+=" -no-ansi-alias"
+
+    #--------------------------------------------------------------------------#
+    # Use of "-Winline" cause compiler to emit a warning when a function that
+    # is declared inline is not inlined. Inlining is very important to VPIC
+    # performance and it is useful to know if compiler has not inlined a
+    # function that was assumed to be inlined.
+    #
+    # Use of "-craype-verbose" causes Cray compiler wrapper script to print
+    # command it is forwarding to actual compiler for invocation. This is very
+    # useful for producing a build log to make sure compiler is being invoked
+    # with expected options.
+    #--------------------------------------------------------------------------#
+
+    FLAGS_CXX_COMPILER+=" -Winline"
+    if [ x$craype = x1 ]; then
+        FLAGS_CXX_COMPILER+=" -craype-verbose"
+    fi
+
+    #--------------------------------------------------------------------------#
+    # Use of "-qopt-report=5" specifies level of detail in compiler reports.
+    # This is the maximum level of detail.
+    #
+    # Use of "-qopt-report-phase=all" causes all phases of compilation process
+    # to provide output for compiler reports. Compiler reports are useful for
+    # understanding how compiler is optimizing various parts of VPIC.
+    #
+    # Use of "-diag-disable 10397" disables printing of diagnostic message
+    # that compiler reports are being generated.
+    #--------------------------------------------------------------------------#
+
+    FLAGS_CXX_COMPILER+=" -qopt-report=5"
+    FLAGS_CXX_COMPILER+=" -qopt-report-phase=all"
+    FLAGS_CXX_COMPILER+=" -diag-disable 10397"
+
+    #--------------------------------------------------------------------------#
+    # Use of "-Wl,--export-dynamic" removes following type of VPIC warnings.
+    #
+    # Unable to find a safely writable symbol that corresponds to address
+    # 432af0 (the closest match was "(null)" from "./lpi_2d_F6_test.Linux").
+    # Writing out the raw address instead and keeping my fingers crossed.
+    #--------------------------------------------------------------------------#
+
+    FLAGS_CXX_COMPILER+=" -Wl,--export-dynamic"
+
+    #--------------------------------------------------------------------------#
+    # Use of "-dynamic" causes Cray compiler wrapper to direct compiler driver
+    # to link dynamic libraries at runtime instead of static libraries. The
+    # default on Cray systems is to link static libraries. It is important for
+    # many tools, especially performance analysis tools, to have an executable
+    # that has been linked dynamically to system libraries and MPI libraries.
+    #--------------------------------------------------------------------------#
+
+    if [ x$craype = x1 ]; then
+        FLAGS_CXX_COMPILER+=" -dynamic"
+    fi
+
+    #--------------------------------------------------------------------------#
+    # Use of "-qopt-zmm-usage=high" causes the compiler to generate zmm code,
+    # i.e. AVX-512 code, without any restrictions. Extensive use of AVX-512
+    # code causes the CPU core to down clock or throttle to avoid overheating.
+    # The default is for the compiler to use some internal limits on how much
+    # AVX-512 instructions are used. This is relevant on ATS-1 systems only
+    # for KNL processors.
+    #--------------------------------------------------------------------------#
+
+    if [ x$VCPU = xknl ]; then
+        FLAGS_CXX_COMPILER+=" -qopt-zmm-usage=high"
+    fi
+
+    #--------------------------------------------------------------------------#
+    # Use "-g" to provide debug symbols in the executable.  In general, use of
+    # "-g" with modern compilers does not degrade performance and provides
+    # information required by many tools such as debugging and performance
+    # analysis tools.
+    #
+    # Use of "-O3" provides fairly aggressive optimization. When using vector
+    # intrinsics versions, most of the optimization is explicit in the
+    # intrinsics implementations. Reasonable alternatives to "-O3" could be
+    # "-O2" or "-Ofast". These alternatives should be benchmarked sometime.
+    #--------------------------------------------------------------------------#
+
+    FLAGS_C_COMPILER="-g -O3"
+
+    #--------------------------------------------------------------------------#
+    # Use of "-inline-forceinline" overrides default heuristics of compiler
+    # and forces inlining of functions marked with inline keyword if compiler
+    # is able to inline. For VPIC, this option has mainly been used when using
+    # a portable implementation to force inlining by compiler and also when
+    # use of "-Winline" option identifies functions not being inlined that are
+    # marked with inline keyword.
+    #
+    # Use of "-qoverride-limits" cause certain internal compiler limits to be
+    # ignored that are used to limit memory usage and excessive compile times
+    # by the compiler.
+    #
+    # Use of "-vec-threshold0" ignores compiler heuristics and causes loops
+    # which can be vectorized to always be vectorized, regardless of the
+    # amount of computational work in the loop.
+    #--------------------------------------------------------------------------#
+
+    FLAGS_C_COMPILER+=" -inline-forceinline"
+    #FLAGS_C_COMPILER+=" -vec-threshold0"
+    FLAGS_C_COMPILER+=" -qoverride-limits"
+
+    #--------------------------------------------------------------------------#
+    # Use of "-no-ansi-alias" informs compiler that VPIC does not obey ANSI
+    # aliasing rules which can reduce available optimizations.
+    #--------------------------------------------------------------------------#
+
+    FLAGS_C_COMPILER+=" -no-ansi-alias"
+
+    #--------------------------------------------------------------------------#
+    # Use of "-Winline" cause compiler to emit a warning when a function that
+    # is declared inline is not inlined. Inlining is very important to VPIC
+    # performance and it is useful to know if compiler has not inlined a
+    # function that was assumed to be inlined.
+    #
+    # Use of "-craype-verbose" causes Cray compiler wrapper script to print
+    # command it is forwarding to actual compiler for invocation. This is very
+    # useful for producing a build log to make sure compiler is being invoked
+    # with expected options.
+    #--------------------------------------------------------------------------#
+
+    FLAGS_C_COMPILER+=" -Winline"
+    if [ x$craype = x1 ]; then
+        FLAGS_C_COMPILER+=" -craype-verbose"
+    fi
+
+    #--------------------------------------------------------------------------#
+    # Use of "-qopt-report=5" specifies level of detail in compiler reports.
+    # This is the maximum level of detail.
+    #
+    # Use of "-qopt-report-phase=all" causes all phases of compilation process
+    # to provide output for compiler reports. Compiler reports are useful for
+    # understanding how compiler is optimizing various parts of VPIC.
+    #
+    # Use of "-diag-disable 10397" disables printing of diagnostic message
+    # that compiler reports are being generated.
+    #--------------------------------------------------------------------------#
+
+    FLAGS_C_COMPILER+=" -qopt-report=5"
+    FLAGS_C_COMPILER+=" -qopt-report-phase=all"
+    FLAGS_C_COMPILER+=" -diag-disable 10397"
+
+    #--------------------------------------------------------------------------#
+    # Use of "-Wl,--export-dynamic" removes following type of VPIC warnings.
+    #
+    # Unable to find a safely writable symbol that corresponds to address
+    # 432af0 (the closest match was "(null)" from "./lpi_2d_F6_test.Linux").
+    # Writing out the raw address instead and keeping my fingers crossed.
+    #--------------------------------------------------------------------------#
+
+    FLAGS_C_COMPILER+=" -Wl,--export-dynamic"
+
+    #--------------------------------------------------------------------------#
+    # Use of "-dynamic" causes Cray compiler wrapper to direct compiler driver
+    # to link dynamic libraries at runtime instead of static libraries. The
+    # default on Cray systems is to link static libraries. It is important for
+    # many tools, especially performance analysis tools, to have an executable
+    # that has been linked dynamically to system libraries and MPI libraries.
+    #--------------------------------------------------------------------------#
+
+    if [ x$craype = x1 ]; then
+        FLAGS_C_COMPILER+=" -dynamic"
+    fi
+
+    #--------------------------------------------------------------------------#
+    # Use of "-qopt-zmm-usage=high" causes the compiler to generate zmm code,
+    # i.e. AVX-512 code, without any restrictions. Extensive use of AVX-512
+    # code causes the CPU core to down clock or throttle to avoid overheating.
+    # The default is for the compiler to use some internal limits on how much
+    # AVX-512 instructions are used. This is relevant on ATS-1 systems only
+    # for KNL processors.
+    #--------------------------------------------------------------------------#
+
+    if [ x$VCPU = xknl ]; then
+        FLAGS_C_COMPILER+=" -qopt-zmm-usage=high"
+    fi
+fi
+
+#------------------------------------------------------------------------------#
+# Configure options for the GNU compilers.
+#------------------------------------------------------------------------------#
+
+if [ "$VCOM" = "GNU" ]
+then
+    #--------------------------------------------------------------------------#
+    # Use "-g" to provide debug symbols in the executable.  In general, use of
+    # "-g" with modern compilers does not degrade performance and provides
+    # information required by many tools such as debugging and performance
+    # analysis tools.
+    #
+    # Use of "-O2" provides fairly aggressive optimization. When using vector
+    # intrinsics versions, most of the optimization is explicit in the
+    # intrinsics implementations. Reasonable alternatives to "-O2" could be
+    # "-O3" or "-Ofast". These alternatives should be benchmarked sometime.
+    #--------------------------------------------------------------------------#
+
+    FLAGS_CXX_COMPILER="-g -O2"
+
+    #--------------------------------------------------------------------------#
+    # Use of "-ffast-math" causes compiler to relax various IEEE or ISO rules
+    # and specifications for math functions which can result in faster code.
+    #
+    # Use of "-fno-unsafe-math-optimizations" turns off some unsafe math
+    # optimizations that got turned on by use of "-ffast-math" option. Some
+    # comments in VPIC source code indicate need for this with older compilers.
+    # This should be checked some time to see if it is still a relevant issue.
+    #--------------------------------------------------------------------------#
+
+    FLAGS_CXX_COMPILER+=" -ffast-math"
+    FLAGS_CXX_COMPILER+=" -fno-unsafe-math-optimizations"
+
+    #--------------------------------------------------------------------------#
+    # Use of "-fomit-frame-pointer" prevents keeping the frame pointer in a
+    # register for functions that do not need one. This can make an extra
+    # register available in many functions and reduce number of overall
+    # instructions. Some profiling should be done to measure the benefit of
+    # using this option.
+    #--------------------------------------------------------------------------#
+
+    FLAGS_CXX_COMPILER+=" -fomit-frame-pointer"
+
+    #--------------------------------------------------------------------------#
+    # Use of "-fno-strict-aliasing" informs compiler that VPIC does not obey
+    # ANSI aliasing rules which can reduce available optimizations.
+    #--------------------------------------------------------------------------#
+
+    FLAGS_CXX_COMPILER+=" -fno-strict-aliasing"
+
+    #--------------------------------------------------------------------------#
+    # Use of "-Winline" cause compiler to emit a warning when a function that
+    # is declared inline is not inlined. Inlining is very important to VPIC
+    # performance and it is useful to know if compiler has not inlined a
+    # function that was assumed to be inlined.
+    #--------------------------------------------------------------------------#
+
+    FLAGS_CXX_COMPILER+=" -Winline"
+
+    #--------------------------------------------------------------------------#
+    # Use of "-rdynamic" removes the following type of VPIC warnings.
+    #
+    # Unable to find a safely writable symbol that corresponds to address
+    # 432af0 (the closest match was "(null)" from "./lpi_2d_F6_test.Linux").
+    # Writing out the raw address instead and keeping my fingers crossed.
+    #
+    # From g++ man page: Pass the flag -export-dynamic to the ELF linker, on
+    # targets that support it. This instructs the linker to add all symbols,
+    # not only used ones, to the dynamic symbol table. This option is needed
+    # for some uses of "dlopen" or to allow obtaining backtraces from within
+    # a program.
+    #--------------------------------------------------------------------------#
+
+    FLAGS_CXX_COMPILER+=" -rdynamic"
+
+    #--------------------------------------------------------------------------#
+    # Use of "-dynamic" causes Cray compiler wrapper to direct compiler driver
+    # to link dynamic libraries at runtime instead of static libraries. The
+    # default on Cray systems is to link static libraries. It is important for
+    # many tools, especially performance analysis tools, to have an executable
+    # that has been linked dynamically to system libraries and MPI libraries.
+    #--------------------------------------------------------------------------#
+
+    if [ x$craype = x1 ]; then
+        FLAGS_CXX_COMPILER+=" -dynamic"
+    fi
+
+    #--------------------------------------------------------------------------#
+    # Use of "-march=knl" or "-march=haswell" causes g++ to generate code
+    # specific to and optimized for the specific architecture of either KNL
+    # or Haswell. It appears that the Cray wrappers already do this correctly
+    # for KNL but it seems they may not for Haswell.
+    #--------------------------------------------------------------------------#
+
+    FLAGS_CXX_COMPILER+=" -march=${VCPU}"
+
+    #--------------------------------------------------------------------------#
+    # Use "-g" to provide debug symbols in the executable.  In general, use of
+    # "-g" with modern compilers does not degrade performance and provides
+    # information required by many tools such as debugging and performance
+    # analysis tools.
+    #
+    # Use of "-O2" provides fairly aggressive optimization. When using vector
+    # intrinsics versions, most of the optimization is explicit in the
+    # intrinsics implementations. Reasonable alternatives to "-O2" could be
+    # "-O3" or "-Ofast". These alternatives should be benchmarked sometime.
+    #--------------------------------------------------------------------------#
+
+    FLAGS_C_COMPILER="-g -O2"
+
+    #--------------------------------------------------------------------------#
+    # Use of "-ffast-math" causes compiler to relax various IEEE or ISO rules
+    # and specifications for math functions which can result in faster code.
+    #
+    # Use of "-fno-unsafe-math-optimizations" turns off some unsafe math
+    # optimizations that got turned on by use of "-ffast-math" option. Some
+    # comments in VPIC source code indicate need for this with older compilers.
+    # This should be checked some time to see if it is still a relevant issue.
+    #--------------------------------------------------------------------------#
+
+    FLAGS_C_COMPILER+=" -ffast-math"
+    FLAGS_C_COMPILER+=" -fno-unsafe-math-optimizations"
+
+    #--------------------------------------------------------------------------#
+    # Use of "-fomit-frame-pointer" prevents keeping the frame pointer in a
+    # register for functions that do not need one. This can make an extra
+    # register available in many functions and reduce number of overall
+    # instructions. Some profiling should be done to measure the benefit of
+    # using this option.
+    #--------------------------------------------------------------------------#
+
+    FLAGS_C_COMPILER+=" -fomit-frame-pointer"
+
+    #--------------------------------------------------------------------------#
+    # Use of "-fno-strict-aliasing" informs compiler that VPIC does not obey
+    # ANSI aliasing rules which can reduce available optimizations.
+    #--------------------------------------------------------------------------#
+
+    FLAGS_C_COMPILER+=" -fno-strict-aliasing"
+
+    #--------------------------------------------------------------------------#
+    # Use of "-Winline" cause compiler to emit a warning when a function that
+    # is declared inline is not inlined. Inlining is very important to VPIC
+    # performance and it is useful to know if compiler has not inlined a
+    # function that was assumed to be inlined.
+    #--------------------------------------------------------------------------#
+
+    FLAGS_C_COMPILER+=" -Winline"
+
+    #--------------------------------------------------------------------------#
+    # Use of "-rdynamic" removes the following type of VPIC warnings.
+    #
+    # Unable to find a safely writable symbol that corresponds to address
+    # 432af0 (the closest match was "(null)" from "./lpi_2d_F6_test.Linux").
+    # Writing out the raw address instead and keeping my fingers crossed.
+    #
+    # From gcc man page: Pass the flag -export-dynamic to the ELF linker, on
+    # targets that support it. This instructs the linker to add all symbols,
+    # not only used ones, to the dynamic symbol table. This option is needed
+    # for some uses of "dlopen" or to allow obtaining backtraces from within
+    # a program.
+    #--------------------------------------------------------------------------#
+
+    FLAGS_C_COMPILER+=" -rdynamic"
+
+    #--------------------------------------------------------------------------#
+    # Use of "-dynamic" causes Cray compiler wrapper to direct compiler driver
+    # to link dynamic libraries at runtime instead of static libraries. The
+    # default on Cray systems is to link static libraries. It is important for
+    # many tools, especially performance analysis tools, to have an executable
+    # that has been linked dynamically to system libraries and MPI libraries.
+    #--------------------------------------------------------------------------#
+
+    if [ x$craype = x1 ]; then
+        FLAGS_C_COMPILER+=" -dynamic"
+    fi
+
+    #--------------------------------------------------------------------------#
+    # Use of "-march=knl" or "-march=haswell" causes gcc to generate code
+    # specific to and optimized for the specific architecture of either KNL
+    # or Haswell. It appears that the Cray wrappers already do this correctly
+    # for KNL but it seems they may not for Haswell.
+    #--------------------------------------------------------------------------#
+
+    FLAGS_C_COMPILER+=" -march=${VCPU}"
+fi
+
+#------------------------------------------------------------------------------#
+# Configure options for the Cray compilers.
+#------------------------------------------------------------------------------#
+
+if [ "$VCOM" = "CCE" ]
+then
+    #--------------------------------------------------------------------------#
+    #
+    #--------------------------------------------------------------------------#
+
+    FLAGS_CXX_COMPILER="-g -O2"
+    #FLAGS_CXX_COMPILER+=" -hlist=ad"
+    #FLAGS_CXX_COMPILER+=" -hipa5"
+    FLAGS_CXX_COMPILER+=" -Wl,--export-dynamic"
+    #FLAGS_CXX_COMPILER+=" -rdynamic"
+    FLAGS_CXX_COMPILER+=" -dynamic"
+
+    #--------------------------------------------------------------------------#
+    #
+    #--------------------------------------------------------------------------#
+
+    FLAGS_C_COMPILER="-g -O2"
+    #FLAGS_C_COMPILER+=" -hlist=ad"
+    #FLAGS_C_COMPILER+=" -hipa5"
+    FLAGS_C_COMPILER+=" -Wl,--export-dynamic"
+    #FLAGS_C_COMPILER+=" -rdynamic"
+    FLAGS_C_COMPILER+=" -dynamic"
+fi
+
+#------------------------------------------------------------------------------#
+# Configure options for the PGI compilers.
+#------------------------------------------------------------------------------#
+
+if [ "$VCOM" = "PGI" ]
+then
+    #--------------------------------------------------------------------------#
+    #
+    #--------------------------------------------------------------------------#
+
+    FLAGS_CXX_COMPILER="-g -O2"
+    FLAGS_CXX_COMPILER+=" -Wl,--export-dynamic"
+
+    #--------------------------------------------------------------------------#
+    #
+    #--------------------------------------------------------------------------#
+
+    FLAGS_C_COMPILER="-g -O2"
+    FLAGS_C_COMPILER+=" -Wl,--export-dynamic"
+fi
+
+#------------------------------------------------------------------------------#
+# This ends user configuration section.
+#
+# No changes required below unless VPIC build system has been extended or the
+# module system on ATS-1 machines has changed in some fundamental way.
+#------------------------------------------------------------------------------#
+
+#------------------------------------------------------------------------------#
+# Configure thread model.
+#------------------------------------------------------------------------------#
+
+if [ "$VTHR" = "PTH" ]
+then
+    SET_OPENMP="OFF"
+    SET_PTHREADS="ON"
+fi
+
+if [ "$VTHR" = "OMP" ]
+then
+    SET_OPENMP="ON"
+    SET_PTHREADS="OFF"
+fi
+
+#------------------------------------------------------------------------------#
+# Configure particle sort method.
+#------------------------------------------------------------------------------#
+
+if [ "$VSORT" = "LSORT" ]
+then
+    SET_LEGACY_SORT="ON"
+fi
+
+module list
+
+#------------------------------------------------------------------------------#
+# create a new cache for cmake and load it
+#------------------------------------------------------------------------------#
+create_cmake_cache
+set_cache_string CMAKE_BUILD_TYPE         $SET_BUILD_TYPE
+set_cache_bool   ENABLE_INTEGRATED_TESTS  $SET_INTEGRATED_TESTS
+set_cache_bool   ENABLE_UNIT_TESTS        $SET_UNIT_TESTS
+set_cache_bool   ENABLE_OPENSSL           $SET_ENABLE_OPENSSL
+set_cache_bool   DISABLE_DYNAMIC_RESIZING $SET_DISABLE_DYNAMIC_RESIZING
+set_cache_string SET_MIN_NUM_PARTICLES    $SET_PARTICLE_MIN_NUM
+set_cache_bool   USE_LEGACY_SORT          $SET_LEGACY_SORT
+set_cache_bool   USE_V4_PORTABLE          $SET_V4_PORTABLE
+set_cache_bool   USE_V4_SSE               $SET_V4_SSE
+set_cache_bool   USE_V4_AVX               $SET_V4_AVX
+set_cache_bool   USE_V4_AVX2              $SET_V4_AVX2
+set_cache_bool   USE_V8_PORTABLE          $SET_V8_PORTABLE
+set_cache_bool   USE_V8_AVX               $SET_V8_AVX
+set_cache_bool   USE_V8_AVX2              $SET_V8_AVX2
+set_cache_bool   USE_V16_PORTABLE         $SET_V16_PORTABLE
+set_cache_bool   USE_V16_AVX512           $SET_V16_AVX512
+set_cache_bool   VPIC_PRINT_MORE_DIGITS   $SET_MORE_DIGITS
+set_cache_bool   USE_OPENMP               $SET_OPENMP
+set_cache_bool   USE_PTHREADS             $SET_PTHREADS
+set_cache_bool   BUILD_SHARED_LIBS        $SET_SHARED_LIBS
+set_cache_string CMAKE_C_COMPILER         $VPIC_COMPILER_C
+set_cache_string CMAKE_CXX_COMPILER       $VPIC_COMPILER_CXX
+set_cache_string CMAKE_C_FLAGS            "$FLAGS_C_COMPILER"
+set_cache_string CMAKE_CXX_FLAGS          "$FLAGS_CXX_COMPILER"
+
+# allow user to 'lanl-current-mods initcache' to skip running cmake.
+if [ x$1 = xinitcache ]; then
+    echo ${init_cache} created.
+    echo Now you can run \"cmake -C ${init_cache} src_dir\" to configure.
+    exit 0
+fi
+
+#------------------------------------------------------------------------------#
+# Call cmake command.
+#------------------------------------------------------------------------------#
+# Notes:
+#
+# Use of the "-LAH" command line option to cmake causes cmake to output the
+# values of all of its variables. This is useful information when debugging
+# a failed build.
+#
+# Note that all of the possible VPIC cmake variables relevant to an ATS-1
+# system are set on the command line so that they can all be conditionally
+# configured above through user selections.
+#------------------------------------------------------------------------------#
+
+cmake -LAH -C ${init_cache} ${src_dir}
+
+if [ $? = 0 ]; then
+    echo Now you can run \"make\" to build VPIC.
+fi
+
+#------------------------------------------------------------------------------#
+# Done.
+#------------------------------------------------------------------------------#
+
+#------------------------------------------------------------------------------#
+# vim: syntax=sh
+#------------------------------------------------------------------------------#

--- a/arch/module-fns.sh
+++ b/arch/module-fns.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2019 Carnegie Mellon University,
+# Copyright (c) 2019 Triad National Security, LLC, as operator of
+#     Los Alamos National Laboratory.
+#
+# All rights reserved.
+#
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file. See the AUTHORS file for names of contributors.
+#
+
+#
+# module-fns.sh  functions to interact with the module(1) system
+# 18-Jul-2019  chuck@ece.cmu.edu
+#
+
+#
+# input:
+#  - we assume the set of loaded modules is in ${LOADEDMODULES}
+# output variables:
+#  - VCOM: currently loaded compiler (GNU, INT, CCE, PGI)
+#  - VMPI: currently loaded MPI (CMPI, IMPI, OMPI)
+#  - VCPU: currently selected CPU (broadwell, haswell, knl)
+#  - mod_X: if 'X' module is loaded, set to X's version (or 1 if versionless)
+#
+
+if [ x${LOADEDMODULES} = x ]; then
+    echo "ERROR: No modules loaded.  A compiler, MPI, and cmake are required."
+    exit 1
+fi
+if [ "`printenv | fgrep CRAY_PRGENV`" ]; then
+    craype=1
+else
+    craype=0
+fi
+
+#
+# probe environment for list of loaded modules and their versions
+#
+lmods=`echo ${LOADEDMODULES} | sed -e 's/:/ /g'`
+lmodsidx=0
+for lm in ${lmods}
+do
+    name=`echo $lm | sed -e 's@/.*@@'`
+    vers=`echo $lm | sed -e 's@.*/@@'`
+    if [ x${name} = x${vers} ]; then
+        vers=1      # fake version number for modules without one
+    fi
+    # convert - and . to underline so we can use it as a shell variable
+    vname=`echo ${name} | sed -e 's/-/_/g' -e 's/\./_/g'`
+    eval mod_${vname}=${vers}
+    eval modpos_${vname}=${lmodsidx}
+    lmodsidx=`expr ${lmodsidx} + 1`
+done
+
+#
+# look for obvious problems...
+#
+if [ x${mod_cmake} = x ]; then
+    echo "ERROR: A cmake module must be loaded to compile VPIC."
+    echo "Try 'module load cmake'"
+    exit 1
+fi
+if [ x${mod_craype_hugepages2M} != x ]; then
+    echo "ERROR: craype-hugepages2M causes VPIC memory usage issues"
+    echo "Try 'module unload craype-hugepages2M'"
+    exit 1
+fi
+
+#
+# determine which compiler is loaded and set VCOM
+#
+if [ x${mod_gcc} != x ]; then
+    VCOM="GNU"
+    VCOMVER=${mod_gcc}
+    VCOMPOS=${modpos_gcc}
+elif [ x${mod_intel} != x ]; then
+    VCOM="INT"
+    VCOMVER=${mod_intel}
+    VCOMPOS=${modpos_intel}
+elif [ x${mod_cce} != x ]; then
+    VCOM="CCE"
+    VCOMVER=${mod_cce}
+    VCOMPOS=${modpos_cce}
+elif [ x${mod_pgi} != x ]; then
+    VCOM="PGI"
+    VCOMVER=${mod_pgi}
+    VCOMPOS=${modpos_pgi}
+else
+    echo "ERROR: no compiler module loaded."
+    if [ ${craype} = 1 ]; then
+        echo "Try 'module load PrgEnv-gnu' (or PrgEnv-intel, PrgEnv-cray, etc.)"
+    else
+        echo "Try 'module load gcc' (or intel, pgi, etc.)"
+    fi
+    exit 1
+fi
+
+#
+# determine which MPI is loaded
+#
+if [ x${mod_cray_mpich} != x ]; then
+    VMPI="CMPI"
+    VMPIVER=${mod_cray_mpich}
+elif [ x${mod_intel_mpi} != x ]; then
+    VMPI="IMPI"
+    VMPIVER=${mod_intel_mpi}
+elif [ x${mod_openmpi} != x ]; then
+    VMPI="OMPI"
+    VMPIVER=${mod_openmpi}
+    if [ x$craype = x0 -a ${modpos_openmpi} -lt ${VCOMPOS} ]; then
+        #
+        # XXX: there is one complete compiled version of openmpi for
+        # every version of every compiled installed on the system.
+        # when you "module load openmpi" it looks to see what compiler
+        # has been loaded and uses that to select which version of
+        # openmpi to add to your path.   if you load openmpi before
+        # loading the compiler, the module system cannot determine
+        # which compiled version of openmpi to put into your path.
+        # the openmpi module should raise an error in this case, but
+        # instead it picks up the non-module gcc from /usr/bin and
+        # tries to use that, and that doesn't work as intented...
+        # so we catch it here and die.
+        #
+        echo "ERROR: openmpi module added before a compiler module."
+        echo "Try 'module purge' and load a compiler first, then openmpi."
+        exit 1
+    fi
+else
+    echo "ERROR: no MPI module loaded."
+    echo "Try 'module load openmpi' (or intel-mpi, cray-mpich, etc.)"
+    exit 1
+fi
+
+#
+# heuristic to choose a CPU target
+#
+if [ x${mod_craype_haswell} != x ]; then
+    VCPU="haswell"
+elif [ x${mod_craype_mic_knl} != x ]; then
+    VCPU="knl"
+else
+    VCPU="broadwell"      # XXX best guess
+fi
+
+
+echo "Compiler loaded: ${VCOM} version ${VCOMVER}"
+echo "MPI loaded: ${VMPI} version ${VMPIVER}"
+echo "CPU target: ${VCPU}"


### PR DESCRIPTION
The current set of config scripts in arch configure vpic by running
cmake with the config specified on the cmake command line using cmake
cache variables (i.e. the "-D" flag).  The lanl scripts also force
the module config and run make.  There are two problems with this.
First, users no longer have access to the cmake command line (e.g.
so that they can specify the installation prefix for "make install"
with -DCMAKE_INSTALL_PREFIX=...).  Second, the config processes on
lanl systems differs from non-lanl systems.

This patch adds a new optional way to configure vpic with cmake
that works around these issues.   When an arch script is invoked
with the optional arg "initcache" it generates a file called
"vpic-init-cache.cmake" and stops.  The "vpic-init-cache.cmake"
file contains all the cache variables that the arch script would
have normally put on the command line (with the "-D" flag).

This allows the user (or automated build script) to run cmake
themselves with additional flags by using the "-C" flag to load
the "vpic-init-cache.cmake" file.

For example, to build a test vpic install in /tmp/try one can do:

<pre>
    % ls
    % ../arch/gcc/v4-sse initcache
    ./vpic-init-cache.cmake created.
    Now you can run "cmake -C ./vpic-init-cache.cmake src_dir" to configure.
    %
    % ls
vpic-init-cache.cmake
    %
    % cat vpic-init-cache.cmake
    set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Initial cache" FORCE)
    set(ENABLE_INTEGRATED_TESTS "ON" CACHE BOOL "Initial cache" FORCE)
    set(USE_V4_SSE "ON" CACHE BOOL "Initial cache" FORCE)
    set(CMAKE_C_FLAGS "-rdynamic -fno-strict-aliasing" CACHE STRING "Initial cache" FORCE)
    set(CMAKE_CXX_FLAGS "-rdynamic -fno-strict-aliasing" CACHE STRING "Initial cache" FORCE)
    %
    % cmake -C ./vpic-init-cache.cmake -DCMAKE_INSTALL_PREFIX=/tmp/try ..
    loading initial cache file ./vpic-init-cache.cmake
    -- The C compiler identification is GNU 7.4.0
    -- The CXX compiler identification is GNU 7.4.0
    -- Check for working C compiler: /usr/bin/cc
    -- Check for working C compiler: /usr/bin/cc -- works
    -- Detecting C compiler ABI info
    -- Detecting C compiler ABI info - done
    -- Detecting C compile features
    -- Detecting C compile features - done
    -- Check for working CXX compiler: /usr/bin/c++
    -- Check for working CXX compiler: /usr/bin/c++ -- works
    -- Detecting CXX compiler ABI info
    -- Detecting CXX compiler ABI info - done
    -- Detecting CXX compile features
    -- Detecting CXX compile features - done
    -- Found MPI_C: /usr/lib/x86_64-linux-gnu/libmpich.so (found version "3.1")
    -- Found MPI_CXX: /usr/lib/x86_64-linux-gnu/libmpichcxx.so (found version "3.1")
    -- Found MPI: TRUE (found version "3.1")
    -- Looking for pthread.h
    -- Looking for pthread.h - found
    -- Looking for pthread_create
    -- Looking for pthread_create - not found
    -- Looking for pthread_create in pthreads
    -- Looking for pthread_create in pthreads - not found
    -- Looking for pthread_create in pthread
    -- Looking for pthread_create in pthread - found
    -- Found Threads: TRUE
    -- Configuring done
    -- Generating done
    -- Build files have been written to: /proj/TableFS/data/chuck/src/lanl/devel/vpic/b
    %
</pre>

then a "make install" would build and install vpic in CMAKE_INSTALL_PREFIX
("/tmp/try" in the example above).

To use this with LANL-style builds, we decouple the module configuration
from vpic configuration.   We assume LANL users will configure all their
modules the way they want them prior to trying to configure vpic.  We do
not change the module config.   Instead, we look into the environment to
determine the current module configuration and use that.   To support
this mode of operation we introduce a new script "arch/lanl-current-mods"
that combines ATS1 and CTS1 configs into a single script named
"lanl-current-mods" ... this is used in the same way as noted above,
but internally it includes extra code to examine and sanity check the
currently loaded set of modules.  Here is an example from GR:

<pre>
    [ccranor@gr-fe2 b]$ ../arch/lanl-current-mods initcache
    ERROR: No modules loaded.  A compiler, MPI, and cmake are required.
    [ccranor@gr-fe2 b]$
    [ccranor@gr-fe2 b]$ module load gcc openmpi cmake
    [ccranor@gr-fe2 b]$
    [ccranor@gr-fe2 b]$ ../arch/lanl-current-mods initcache
    Compiler loaded: GNU version 7.4.0
    MPI loaded: OMPI version 2.1.2
    CPU target: broadwell

    Currently Loaded Modules:
      1) gcc/7.4.0   2) openmpi/2.1.2   3) cmake/3.14.6

    ./vpic-init-cache.cmake created.
    Now you can run "cmake -C ./vpic-init-cache.cmake src_dir" to configure.
    [ccranor@gr-fe2 b]$
    [ccranor@gr-fe2 b]$ cat vpic-init-cache.cmake
    set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Initial cache" FORCE)
    set(ENABLE_INTEGRATED_TESTS "OFF" CACHE BOOL "Initial cache" FORCE)
    set(ENABLE_UNIT_TESTS "OFF" CACHE BOOL "Initial cache" FORCE)
    set(ENABLE_OPENSSL "OFF" CACHE BOOL "Initial cache" FORCE)
    set(DISABLE_DYNAMIC_RESIZING "OFF" CACHE BOOL "Initial cache" FORCE)
    set(SET_MIN_NUM_PARTICLES "128" CACHE STRING "Initial cache" FORCE)
    set(USE_LEGACY_SORT "ON" CACHE BOOL "Initial cache" FORCE)
    set(USE_V4_PORTABLE "OFF" CACHE BOOL "Initial cache" FORCE)
    set(USE_V4_SSE "OFF" CACHE BOOL "Initial cache" FORCE)
    set(USE_V4_AVX "OFF" CACHE BOOL "Initial cache" FORCE)
    set(USE_V4_AVX2 "ON" CACHE BOOL "Initial cache" FORCE)
    set(USE_V8_PORTABLE "OFF" CACHE BOOL "Initial cache" FORCE)
    set(USE_V8_AVX "OFF" CACHE BOOL "Initial cache" FORCE)
    set(USE_V8_AVX2 "ON" CACHE BOOL "Initial cache" FORCE)
    set(USE_V16_PORTABLE "OFF" CACHE BOOL "Initial cache" FORCE)
    set(USE_V16_AVX512 "OFF" CACHE BOOL "Initial cache" FORCE)
    set(VPIC_PRINT_MORE_DIGITS "OFF" CACHE BOOL "Initial cache" FORCE)
    set(USE_OPENMP "OFF" CACHE BOOL "Initial cache" FORCE)
    set(USE_PTHREADS "ON" CACHE BOOL "Initial cache" FORCE)
    set(BUILD_SHARED_LIBS "OFF" CACHE BOOL "Initial cache" FORCE)
    set(CMAKE_C_COMPILER "mpicc" CACHE STRING "Initial cache" FORCE)
    set(CMAKE_CXX_COMPILER "mpicxx" CACHE STRING "Initial cache" FORCE)
    set(CMAKE_C_FLAGS "-g -O2 -ffast-math -fno-unsafe-math-optimizations -fomit-frame-pointer -fno-strict-aliasing -Winline -rdynamic -march=broadwell" CACHE STRING "Initial cache" FORCE)
    set(CMAKE_CXX_FLAGS "-g -O2 -ffast-math -fno-unsafe-math-optimizations -fomit-frame-pointer -fno-strict-aliasing -Winline -rdynamic -march=broadwell" CACHE STRING "Initial cache" FORCE)
    [ccranor@gr-fe2 b]$
</pre>

Now you can simply do:

<pre>
    % cmake -C ./vpic-init-cache.cmake -DCMAKE_INSTALL_PREFIX=/tmp/try ..
</pre>

in the same way as the non-lanl example above and then do "make install"
to build.

To make this work, we introduce additional shell functions in
arch/cmake-fns.sh (to create and append to the "./vpic-init-cache.cmake" file)
and arch/module-fns.sh (to examine + sanity check the currently loaded
modules and use that into to set VCOM, VMPI, and VCPU).

The new "arch/lanl-current-mods" script is a combined version of
lanl-ats1-hsw, lanl-ats1-knl, and lanl-cts1 adapted to work with
arch/module-fns.sh.

The arch/gcc/* files were also adapted to use "arch/cmake-fns.sh" and
support the "initcache" arg.