### PR TITLE
update global_particle_id branch

### DIFF
--- a/src/boundary/boundary_p.cc
+++ b/src/boundary/boundary_p.cc
@@ -376,6 +376,8 @@ boundary_p( particle_bc_t       * RESTRICT pbc_list,
         p0[i] = p0[np];
 
         #endif
+
+        p_id[i] = p_id[np];    /* keep p_id[] in sync with p[] */
       }
 
       sp->np = np;
@@ -478,6 +480,7 @@ boundary_p( particle_bc_t       * RESTRICT pbc_list,
     {
       particle_mover_t * new_pm;
       particle_t       * new_p;
+      size_t           * new_p_id;
 
       n = sp->np + max_inj;
 
@@ -499,7 +502,15 @@ boundary_p( particle_bc_t       * RESTRICT pbc_list,
 
         FREE_ALIGNED( sp->p );
 
+        /* changes made to p[] must be mirrored in p_id[] */
+        MALLOC_ALIGNED( new_p_id, n, 128 );
+
+        COPY( new_p_id, sp->p_id, sp->np );
+
+        FREE_ALIGNED( sp->p_id );
+
         sp->p      = new_p;
+        sp->p_id   = new_p_id;
         sp->max_np = n;
       }
 
@@ -525,7 +536,15 @@ boundary_p( particle_bc_t       * RESTRICT pbc_list,
 
         FREE_ALIGNED( sp->p );
 
+        /* changes made to p[] must be mirrored in p_id[] */
+        MALLOC_ALIGNED( new_p_id, n, 128 );
+
+        COPY( new_p_id, sp->p_id, sp->np );
+
+        FREE_ALIGNED( sp->p_id );
+
         sp->p      = new_p;
+        sp->p_id   = new_p_id;
         sp->max_np = n;
       }
 

--- a/src/boundary/boundary_p.cc
+++ b/src/boundary/boundary_p.cc
@@ -76,7 +76,7 @@ boundary_p( particle_bc_t       * RESTRICT pbc_list,
 
   int n_send[6], n_recv[6], n_ci;
 
-  species_t * sp;
+  species_t* sp;
 
   int face;
 

--- a/src/emitter/child_langmuir.cc
+++ b/src/emitter/child_langmuir.cc
@@ -1,5 +1,6 @@
 #define IN_emitter
 #include "emitter_private.h"
+#include "../vpic/vpic.h"
 
 /* Private interface *********************************************************/
 
@@ -42,6 +43,7 @@ emit_child_langmuir( child_langmuir_t * RESTRICT              cl,
   /**/  rng_t            * RESTRICT              rng = cl->rng;
 
   /**/  particle_t       * RESTRICT ALIGNED(128) p   = sp->p;
+  /**/  size_t           * RESTRICT ALIGNED(128) p_id = sp->p_id;
   /**/  particle_mover_t * RESTRICT ALIGNED(128) pm  = sp->pm;
   /**/  grid_t           * RESTRICT              g   = sp->g;
 
@@ -98,6 +100,7 @@ emit_child_langmuir( child_langmuir_t * RESTRICT              cl,
         p[np].u##Y = u##Y;                                              \
         p[np].u##Z = u##Z;                                              \
         p[np].w    = w;                                                 \
+        p_id[np] = sp->vsim->gen_particle_id(np, sp->max_np);           \
         accumulate_rhob( f, p+np, g, -qsp );                            \
         np++;                                                           \
                                                                         \

--- a/src/emitter/child_langmuir.cc
+++ b/src/emitter/child_langmuir.cc
@@ -100,7 +100,7 @@ emit_child_langmuir( child_langmuir_t * RESTRICT              cl,
         p[np].u##Y = u##Y;                                              \
         p[np].u##Z = u##Z;                                              \
         p[np].w    = w;                                                 \
-        p_id[np] = sp->vsim->gen_particle_id(np, sp->max_np);           \
+        p_id[np] = sp->generate_particle_id(np, sp->max_np);            \
         accumulate_rhob( f, p+np, g, -qsp );                            \
         np++;                                                           \
                                                                         \

--- a/src/species_advance/species_advance.cc
+++ b/src/species_advance/species_advance.cc
@@ -32,6 +32,7 @@ checkpt_species( const species_t * sp )
   CHECKPT_ALIGNED( sp->partition, sp->g->nv+1, 128 );
   CHECKPT_PTR( sp->g );
   CHECKPT_PTR( sp->next );
+  CHECKPT_PTR( sp->vsim );
 }
 
 species_t *
@@ -46,6 +47,7 @@ restore_species( void )
   RESTORE_ALIGNED( sp->partition );
   RESTORE_PTR( sp->g );
   RESTORE_PTR( sp->next );
+  RESTORE_PTR( sp->vsim );
   return sp;
 }
 
@@ -123,7 +125,8 @@ species( const char * name,
          size_t max_local_nm,
          int sort_interval,
          int sort_out_of_place,
-         grid_t * g )
+         grid_t * g,
+         class vpic_simulation *vsim )
 {
   species_t * sp;
   int len = name ? strlen(name) : 0;
@@ -156,6 +159,7 @@ species( const char * name,
   MALLOC_ALIGNED( sp->partition, g->nv+1, 128 );
 
   sp->g = g;
+  sp->vsim = vsim;
 
   /* id, next are set by append species */
 

--- a/src/species_advance/species_advance.cc
+++ b/src/species_advance/species_advance.cc
@@ -32,7 +32,6 @@ checkpt_species( const species_t * sp )
   CHECKPT_ALIGNED( sp->partition, sp->g->nv+1, 128 );
   CHECKPT_PTR( sp->g );
   CHECKPT_PTR( sp->next );
-  CHECKPT_PTR( sp->vsim );
 }
 
 species_t *
@@ -47,7 +46,6 @@ restore_species( void )
   RESTORE_ALIGNED( sp->partition );
   RESTORE_PTR( sp->g );
   RESTORE_PTR( sp->next );
-  RESTORE_PTR( sp->vsim );
   return sp;
 }
 
@@ -125,8 +123,8 @@ species( const char * name,
          size_t max_local_nm,
          int sort_interval,
          int sort_out_of_place,
-         grid_t * g,
-         class vpic_simulation *vsim )
+         grid_t * g
+         )
 {
   species_t * sp;
   int len = name ? strlen(name) : 0;
@@ -159,7 +157,6 @@ species( const char * name,
   MALLOC_ALIGNED( sp->partition, g->nv+1, 128 );
 
   sp->g = g;
-  sp->vsim = vsim;
 
   /* id, next are set by append species */
 

--- a/src/species_advance/species_advance.h
+++ b/src/species_advance/species_advance.h
@@ -54,8 +54,8 @@ species( const char * name,
          size_t max_local_nm,
          int sort_interval,
          int sort_out_of_place,
-         grid_t * g,
-         class vpic_simulation *vsim );
+         grid_t * g
+       );
 
 // FIXME: TEMPORARY HACK UNTIL THIS SPECIES_ADVANCE KERNELS
 // CAN BE CONSTRUCTED ANALOGOUS TO THE FIELD_ADVANCE KERNELS

--- a/src/species_advance/species_advance.h
+++ b/src/species_advance/species_advance.h
@@ -54,7 +54,8 @@ species( const char * name,
          size_t max_local_nm,
          int sort_interval,
          int sort_out_of_place,
-         grid_t * g );
+         grid_t * g,
+         class vpic_simulation *vsim );
 
 // FIXME: TEMPORARY HACK UNTIL THIS SPECIES_ADVANCE KERNELS
 // CAN BE CONSTRUCTED ANALOGOUS TO THE FIELD_ADVANCE KERNELS

--- a/src/species_advance/species_advance_aos.h
+++ b/src/species_advance/species_advance_aos.h
@@ -96,7 +96,6 @@ class species_t {
         grid_t * g;                         // Underlying grid
         species_id id;                      // Unique identifier for a species
         species_t* next;                    // Next species in the list
-        class vpic_simulation *vsim;        // Simulation we belong to
 
         // TODO: this is not technically guaranteed to be unique, but it's good for
         // <how ever many times max_np fits inside the next highest order of

--- a/src/species_advance/species_advance_aos.h
+++ b/src/species_advance/species_advance_aos.h
@@ -1,4 +1,4 @@
-/* 
+/*
  * Written by:
  *   Kevin J. Bowers, Ph.D.
  *   Plasma Physics Group (X-1)
@@ -11,6 +11,8 @@
 
 #ifndef _species_advance_aos_h_
 #define _species_advance_aos_h_
+
+#include <cassert>
 
 typedef int32_t species_id; // Must be 32-bit wide for particle_injector_t
 
@@ -52,48 +54,83 @@ typedef struct particle_injector {
   size_t global_particle_id;
 } particle_injector_t;
 
-typedef struct species {
-  char * name;                        // Species name
-  float q;                            // Species particle charge
-  float m;                            // Species particle rest mass
+class species_t {
+    public:
+        char * name;                        // Species name
+        float q;                            // Species particle charge
+        float m;                            // Species particle rest mass
 
-  int np, max_np;                     // Number and max local particles
-  particle_t * ALIGNED(128) p;        // Array of particles for the species
-  size_t* ALIGNED(128) p_id;          // Array of particles for the species
+        int np, max_np;                     // Number and max local particles
+        particle_t * ALIGNED(128) p;        // Array of particles for the species
+        size_t* ALIGNED(128) p_id;          // Array of particles for the species
 
-  int nm, max_nm;                     // Number and max local movers in use
-  particle_mover_t * ALIGNED(128) pm; // Particle movers
+        int nm, max_nm;                     // Number and max local movers in use
+        particle_mover_t * ALIGNED(128) pm; // Particle movers
 
-  int64_t last_sorted;                // Step when the particles were last
-                                      // sorted.
-  int sort_interval;                  // How often to sort the species
-  int sort_out_of_place;              // Sort method
-  int * ALIGNED(128) partition;       // Static array indexed 0:
-  /**/                                // (nx+2)*(ny+2)*(nz+2).  Each value
-  /**/                                // corresponds to the associated particle
-  /**/                                // array index of the first particle in
-  /**/                                // the cell.  Array is allocated and
-  /**/                                // values computed in sort_p.  Purpose is
-  /**/                                // for implementing collision models
-  /**/                                // This is given in terms of the
-  /**/                                // underlying's grids space filling
-  /**/                                // curve indexing.  Thus, immediately
-  /**/                                // after a sort:
-  /**/                                //   sp->p[sp->partition[g->sfc[i]  ]:
-  /**/                                //         sp->partition[g->sfc[i]+1]-1]
-  /**/                                // are all the particles in voxel
-  /**/                                // with local index i, while:
-  /**/                                //   sp->p[ sp->partition[ j   ]:
-  /**/                                //          sp->partition[ j+1 ] ]
-  /**/                                // are all the particles in voxel
-  /**/                                // with space filling curve index j.
-  /**/                                // Note: SFC NOT IN USE RIGHT NOW THUS
-  /**/                                // g->sfc[i]=i ABOVE.
+        int64_t last_sorted;                // Step when the particles were last
+        // sorted.
+        int sort_interval;                  // How often to sort the species
+        int sort_out_of_place;              // Sort method
+        int * ALIGNED(128) partition;       // Static array indexed 0:
+        /**/                                // (nx+2)*(ny+2)*(nz+2).  Each value
+        /**/                                // corresponds to the associated particle
+        /**/                                // array index of the first particle in
+        /**/                                // the cell.  Array is allocated and
+        /**/                                // values computed in sort_p.  Purpose is
+        /**/                                // for implementing collision models
+        /**/                                // This is given in terms of the
+        /**/                                // underlying's grids space filling
+        /**/                                // curve indexing.  Thus, immediately
+        /**/                                // after a sort:
+        /**/                                //   sp->p[sp->partition[g->sfc[i]  ]:
+        /**/                                //         sp->partition[g->sfc[i]+1]-1]
+        /**/                                // are all the particles in voxel
+        /**/                                // with local index i, while:
+        /**/                                //   sp->p[ sp->partition[ j   ]:
+        /**/                                //          sp->partition[ j+1 ] ]
+        /**/                                // are all the particles in voxel
+        /**/                                // with space filling curve index j.
+        /**/                                // Note: SFC NOT IN USE RIGHT NOW THUS
+        /**/                                // g->sfc[i]=i ABOVE.
 
-  grid_t * g;                         // Underlying grid
-  species_id id;                      // Unique identifier for a species
-  struct species *next;               // Next species in the list
-  class vpic_simulation *vsim;        // Simulation we belong to
-} species_t;
+        grid_t * g;                         // Underlying grid
+        species_id id;                      // Unique identifier for a species
+        species_t* next;                    // Next species in the list
+        class vpic_simulation *vsim;        // Simulation we belong to
+
+        // TODO: this is not technically guaranteed to be unique, but it's good for
+        // <how ever many times max_np fits inside the next highest order of
+        // magnitude> of the initial particle population
+        // TODO: this is probably better in binary, but it's nice for it to be human
+        // readable (for now), as it's essentially for diagnostics
+        /**
+         * @brief Determine a particle ID that has a high probably of being globally
+         * unique
+         *
+         * @param i Current local particle id (i.e slot in the particle array)
+         * @param max_np Max number of particles
+         * @param this_rank Rank to calculate it for (likely origin rank)
+         * @param scale_factor How much to space out the id_base, as a twiddle factor
+         * to avoid overlapping ids (10 is good if you won't overflow..)
+         *
+         * @return The global particle id
+         */
+        size_t generate_particle_id( int i, int max_np, int scale_factor = 1,
+                int this_rank = rank() )
+        {
+            // For now lets use a scheme for the append processor id to local id,
+            // such that if max_np = 128 and we want to generate a local id for
+            // particle 57 we produce:
+            // 1000 + 57 on rank 1 and 2000 + 57 on rank two
+
+            assert(scale_factor > 0);
+
+            // Find max bound by rounding to nearest order of magnitude
+            size_t id_base = ceil( log10(max_np) );
+            size_t global_id = (pow(10,  id_base) * (this_rank*scale_factor) ) + i;
+
+            return global_id;
+        }
+};
 
 #endif // _species_advance_aos_h_

--- a/src/species_advance/species_advance_aos.h
+++ b/src/species_advance/species_advance_aos.h
@@ -93,6 +93,7 @@ typedef struct species {
   grid_t * g;                         // Underlying grid
   species_id id;                      // Unique identifier for a species
   struct species *next;               // Next species in the list
+  class vpic_simulation *vsim;        // Simulation we belong to
 } species_t;
 
 #endif // _species_advance_aos_h_

--- a/src/species_advance/standard/pipeline/sort_p_pipeline.cc
+++ b/src/species_advance/standard/pipeline/sort_p_pipeline.cc
@@ -85,6 +85,8 @@ coarse_sort_pipeline_scalar( sort_p_pipeline_args_t * args,
 {
   const particle_t * RESTRICT ALIGNED(128) p_src = args->p;
   /**/  particle_t * RESTRICT ALIGNED(128) p_dst = args->aux_p;
+  const size_t * RESTRICT ALIGNED(128) p_src_id = args->p_id;
+  /**/  size_t * RESTRICT ALIGNED(128) p_dst_id = args->aux_p_id;
 
   int i, i1;
   int n_subsort = args->n_subsort;
@@ -132,6 +134,8 @@ coarse_sort_pipeline_scalar( sort_p_pipeline_args_t * args,
     p_dst[j] = p_src[i];
 
 #   endif
+
+    p_dst_id[j] = p_src_id[i]; /* keep ids in sync with particles */
   }
 }
 
@@ -146,6 +150,8 @@ subsort_pipeline_scalar( sort_p_pipeline_args_t * args,
 {
   const particle_t * RESTRICT ALIGNED(128) p_src = args->aux_p;
   /**/  particle_t * RESTRICT ALIGNED(128) p_dst = args->p;
+  const size_t * RESTRICT ALIGNED(128) p_src_id = args->aux_p_id;
+  /**/  size_t * RESTRICT ALIGNED(128) p_dst_id = args->p_id;
 
   int i0, i1, v0, v1, i, j, v, sum, count;
 
@@ -209,6 +215,8 @@ subsort_pipeline_scalar( sort_p_pipeline_args_t * args,
       p_dst[j] = p_src[i];
 
 #     endif
+
+      p_dst_id[j] = p_src_id[i]; /* keep ids in sync with particles */
     }
   }
 }
@@ -234,6 +242,8 @@ sort_p_pipeline( species_t * sp )
 
   particle_t * RESTRICT ALIGNED(128) p = sp->p;
   particle_t * RESTRICT ALIGNED(128) aux_p;
+  size_t * RESTRICT ALIGNED(128) p_id = sp->p_id;
+  size_t * RESTRICT ALIGNED(128) aux_p_id;
 
   int n_particle = sp->np;
 
@@ -270,6 +280,8 @@ sort_p_pipeline( species_t * sp )
   // Ensure enough scratch space is allocated for the sorting.
   sz_scratch = ( sizeof( *p ) * n_particle      +
 		 128                            +
+                 sizeof( *p_id ) * n_particle   +
+                 128                            +
                  sizeof( *partition ) * n_voxel +
 		 128                            +
                  sizeof( *coarse_partition ) * ( cp_stride * n_pipeline + 1 ) );
@@ -283,13 +295,16 @@ sort_p_pipeline( species_t * sp )
     max_scratch = sz_scratch;
   }
 
-  aux_p            = ALIGN_PTR( particle_t, scratch,            128 );
-  next             = ALIGN_PTR( int,        aux_p + n_particle, 128 );
-  coarse_partition = ALIGN_PTR( int,        next  + n_voxel,    128 );
+  aux_p            = ALIGN_PTR( particle_t, scratch,               128 );
+  aux_p_id         = ALIGN_PTR( size_t,     aux_p + n_particle,    128 );
+  next             = ALIGN_PTR( int,        aux_p_id + n_particle, 128 );
+  coarse_partition = ALIGN_PTR( int,        next  + n_voxel,       128 );
 
   // Setup pipeline arguments.
   args->p                = p;
   args->aux_p            = aux_p;
+  args->p_id             = p_id;
+  args->aux_p_id         = aux_p_id;
   args->coarse_partition = coarse_partition;
   args->next             = next;
   args->partition        = partition;
@@ -350,8 +365,10 @@ sort_p_pipeline( species_t * sp )
     coarse_partition[0] = 0;
     coarse_partition[1] = n_particle;
 
-    args->p     = aux_p;
-    args->aux_p = p;
+    args->p        = aux_p;
+    args->aux_p    = p;
+    args->p_id     = aux_p_id;
+    args->aux_p_id = p_id;
 
     subsort_pipeline_scalar( args, 0, 1 );
 
@@ -367,5 +384,6 @@ sort_p_pipeline( species_t * sp )
     // TO MOVE SP->P AROUND AND DO MORE MALLOCS PER STEP I.E. HEAP
     // FRAGMENTATION, COULD AVOID THIS COPY.
     COPY( p, aux_p, n_particle );
+    COPY( p_id, aux_p_id, n_particle );
   }
 }

--- a/src/species_advance/standard/pipeline/spa_private.h
+++ b/src/species_advance/standard/pipeline/spa_private.h
@@ -221,6 +221,8 @@ typedef struct sort_p_pipeline_args
 {
   MEM_PTR( particle_t, 128 ) p;                // Particles (0:n-1)
   MEM_PTR( particle_t, 128 ) aux_p;            // Aux particle atorage (0:n-1)
+  MEM_PTR( size_t, 128) p_id;                  // Particle ids (0:n-1)
+  MEM_PTR( size_t, 128 ) aux_p_id;             // Aux particle ids (0:n-1)
   MEM_PTR( int,        128 ) coarse_partition; // Coarse partition storage
   /**/ // (0:max_subsort-1,0:MAX_PIPELINE-1)
   MEM_PTR( int,        128 ) partition;        // Partitioning (0:n_voxel)

--- a/src/util/util_base.h
+++ b/src/util/util_base.h
@@ -294,6 +294,12 @@ extern int _world_size;
 #define world_rank ((int)_world_rank)
 extern int _world_rank;
 
+inline int
+rank() { return world_rank; }
+
+inline int
+nproc() { return world_size; }
+
 // Strip all instances of key from the command line. Returns the
 // number of times key was found.
 

--- a/src/vpic/advance.cc
+++ b/src/vpic/advance.cc
@@ -89,12 +89,14 @@ int vpic_simulation::advance(void) {
     int nm = sp->nm;
     particle_mover_t * RESTRICT ALIGNED(16)  pm = sp->pm + sp->nm - 1;
     particle_t * RESTRICT ALIGNED(128) p0 = sp->p;
+    size_t * RESTRICT ALIGNED(128) p_id0 = sp->p_id;
     for (; nm; nm--, pm--) {
       int i = pm->i; // particle index we are removing
       p0[i].i >>= 3; // shift particle voxel down
       // accumulate the particle's charge to the mesh
       accumulate_rhob( field_array->f, p0+i, sp->g, sp->q );
-      p0[i] = p0[sp->np-1]; // put the last particle into position i
+      p0[i] = p0[sp->np-1];        // put the last particle into position i
+      p_id0[i] = p_id0[sp->np-1];  // move the id up too
       sp->np--; // decrement the number of particles
     }
     sp->nm = 0;

--- a/src/vpic/misc.cc
+++ b/src/vpic/misc.cc
@@ -5,43 +5,7 @@
 //   Los Alamos National Lab
 // March/April 2004 - Original version
 
-#include <cassert>
 #include "vpic.h"
-
-// TODO: this is not technically guaranteed to be unique, but it's good for
-// <how ever many times max_np fits inside the next highest order of
-// magnitude> of the initial particle population
-// TODO: this is probably better in binary, but it's nice for it to be human
-// readable (for now), as it's essentially for diagnostics
-/**
- * @brief Determine a particle ID that has a high probably of being globally
- * unique
- *
- * @param i Current local particle id (i.e slot in the particle array)
- * @param max_np Max number of particles
- * @param this_rank Rank to calculate it for (likely origin rank)
- * @param scale_factor How much to space out the id_base, as a twiddle factor
- * to avoid overlapping ids (10 is good if you won't overflow..)
- *
- * @return The global particle id
- */
-size_t
-vpic_simulation::set_particle_id(int i, int max_np, int this_rank,
-                                 int scale_factor)
-{
-    // For now lets use a scheme for the append processor id to local id,
-    // such that if max_np = 128 and we want to generate a local id for
-    // particle 57 we produce:
-    // 1000 + 57 on rank 1 and 2000 + 57 on rank two
-
-    assert(scale_factor > 0);
-
-    // Find max bound by rounding to nearest order of magnitude
-    size_t id_base = ceil( log10(max_np) );
-    size_t global_id = (pow(10,  id_base) * (this_rank*scale_factor) ) + i;
-
-    return global_id;
-}
 
 // FIXME: MOVE THIS INTO VPIC.HXX TO BE TRULY INLINE
 void
@@ -118,7 +82,7 @@ vpic_simulation::inject_particle( species_t * sp,
   p->w  = w;
 
   // Set particle ID.
-  sp->p_id[old_np] = set_particle_id( old_np, sp->max_np, rank() );
+  sp->p_id[old_np] = sp->generate_particle_id( old_np, sp->max_np );
 
   if( update_rhob ) accumulate_rhob( field_array->f, p, grid, -sp->q );
 

--- a/src/vpic/misc.cc
+++ b/src/vpic/misc.cc
@@ -25,7 +25,9 @@
  *
  * @return The global particle id
  */
-size_t set_particle_id(int i, int max_np, int this_rank, int scale_factor = 1)
+size_t
+vpic_simulation::set_particle_id(int i, int max_np, int this_rank,
+                                 int scale_factor)
 {
     // For now lets use a scheme for the append processor id to local id,
     // such that if max_np = 128 and we want to generate a local id for

--- a/src/vpic/vpic.h
+++ b/src/vpic/vpic.h
@@ -149,11 +149,6 @@ public:
   void predicate_copy(species_t* sp_from, species_t* sp_to, std::function <bool (int)> f);
   void predicate_copy(species_t* sp_from, species_t* sp_to, std::function <bool (particle_t)> f);
 
-  /* XXX: public interface to set_particle_id() for child_langmuir.cc */
-  int gen_particle_id(int np, int maxnp) {
-       return set_particle_id(np, maxnp, rank());
-  }
-
 protected:
 
   // Directly initialized by user
@@ -383,12 +378,6 @@ protected:
 
   ///////////////////
   // Useful accessors
-
-  inline int
-  rank() { return world_rank; }
-
-  inline int
-  nproc() { return world_size; }
 
   inline void
   barrier() { mp_barrier(); }
@@ -629,7 +618,7 @@ protected:
     return append_species( species( name, (float)q, (float)m,
                                     (size_t)max_local_np, (size_t)max_local_nm,
                                     (int)sort_interval, (int)sort_out_of_place,
-                                    grid, this ), &species_list );
+                                    grid ), &species_list );
   }
 
   inline species_t *
@@ -642,14 +631,7 @@ protected:
      return find_species_id( id, species_list );
   }
 
-  ///////////////////
-  // Particle helpers
-
-  size_t set_particle_id( int i, int max_np, int this_rank,
-                          int scale_factor = 1);
-
   // Note: Don't use injection with aging during initialization
-
   // Defaults in the declaration below enable backwards compatibility.
 
   void
@@ -676,7 +658,7 @@ protected:
     size_t * RESTRICT p_id = sp->p_id + sp->np;
     p->dx = dx; p->dy = dy; p->dz = dz; p->i = i;
     p->ux = ux; p->uy = uy; p->uz = uz; p->w = w;
-    *p_id = set_particle_id(sp->np, sp->max_np, rank());
+    *p_id = sp->generate_particle_id( sp->np, sp->max_np );
     sp->np++;
   }
 
@@ -694,7 +676,7 @@ protected:
     particle_mover_t * RESTRICT pm = sp->pm + sp->nm;
     p->dx = dx; p->dy = dy; p->dz = dz; p->i = i;
     p->ux = ux; p->uy = uy; p->uz = uz; p->w = w;
-    *p_id = set_particle_id(sp->np, sp->max_np, rank());
+    *p_id = sp->generate_particle_id( sp->np, sp->max_np );
     pm->dispx = dispx; pm->dispy = dispy; pm->dispz = dispz; pm->i = sp->np-1;
     if( update_rhob ) accumulate_rhob( field_array->f, p, grid, -sp->q );
     sp->nm += move_p( sp->p, pm, accumulator_array->a, grid, sp->q );


### PR DESCRIPTION
nThe PR sync global_particle_id branch with the latest from the devel branch then rebases the changes from the branch on top of that.

In addition, it includes an update I did to keep particles and particle IDs in sync in more places:
     - src/emitter/child_langmuir.cc, in the EMIT_PARTICLES() macro,
       need to assign a id to new particles
     - particle sorting: add id support for remaining cases (pipeline,
       non-pipeline in-place sort)
     - boundary backfill: backfill the p_id too
     - boundary dynamic resizing: resize the p_id[] too
     - inject particle raw: set particle id on new particles
     - additional backfill in advance.cc
