### PR TITLE
Add warning to user if they under specify explicit vectorization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -273,6 +273,16 @@ if (NOT USE_V4 AND NOT USE_V8 AND NOT USE_V16)
     set(NO_EXPLICIT_VECTOR True)
 endif()
 
+# Detect if the user enabled V8/V16 but not v8/v4. If they're not enabled, tell
+# the user instead of giving them a confusing compile error inside a macro
+if (USE_V16 AND (NOT USE_V8 OR NOT USE_V4))
+    message(FATAL_ERROR
+        "You requested V16 but did not also enable both V4 and V8, aborting.")
+endif()
+if (USE_V8 AND NOT USE_V4)
+    message(FATAL_ERROR "You requested V8 but did not also enable V4, aborting.")
+endif()
+
 
 #------------------------------------------------------------------------------#
 # Add options for building with explicit autovec support.


### PR DESCRIPTION
A friendly user pointed out if you set only `V16_AVX` and forget to set `V4_AVX` and `V8_AVX` cmake lets you continue, but the compiler then barfs at you in a very unclear way

@dnystrom1 please sanity check this meets your desired behavior? I'm not aware of any way to only set V16 or V8 (and not V4), but perhaps this is not true? 

Also, I assume you want V8 to be required for V16 to reserve the right to change it in the future? I don't think it's strictly required as-is (V16 does require V4 but not V8)