### PR TITLE
Make global_particle_id compile time optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,7 @@ option(DISABLE_DYNAMIC_RESIZING "Prevent particle arrays from dynamically resizi
 # option to set minimum number of particles
 set(SET_MIN_NUM_PARTICLES AUTO CACHE STRING "Select minimum number of particles to use, if using dynamic particle array resizing")
 
+option(GLOBAL_ID "Give particles a global ID that allows reidentifiaction" OFF)
 
 #------------------------------------------------------------------------------#
 # Create include and link aggregates
@@ -296,6 +297,11 @@ if(VPIC_PRINT_MORE_DIGITS)
   add_definitions(-DVPIC_PRINT_MORE_DIGITS)
   set(VPIC_CXX_FLAGS "${VPIC_CXX_FLAGS} -DVPIC_PRINT_MORE_DIGITS")
 endif(VPIC_PRINT_MORE_DIGITS)
+
+if(GLOBAL_ID)
+  add_definitions(-DVPIC_GLOBAL_ID)
+  set(VPIC_CXX_FLAGS "${VPIC_CXX_FLAGS} -DVPIC_GLOBAL_ID")
+endif()
 
 #------------------------------------------------------------------------------#
 # Handle vpic compile script last.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,7 +91,7 @@ option(DISABLE_DYNAMIC_RESIZING "Prevent particle arrays from dynamically resizi
 # option to set minimum number of particles
 set(SET_MIN_NUM_PARTICLES AUTO CACHE STRING "Select minimum number of particles to use, if using dynamic particle array resizing")
 
-option(GLOBAL_ID "Give particles a global ID that allows reidentifiaction" OFF)
+option(GLOBAL_PARTICLE_ID "Give particles a global ID that allows reidentifiaction" OFF)
 
 #------------------------------------------------------------------------------#
 # Create include and link aggregates
@@ -298,9 +298,9 @@ if(VPIC_PRINT_MORE_DIGITS)
   set(VPIC_CXX_FLAGS "${VPIC_CXX_FLAGS} -DVPIC_PRINT_MORE_DIGITS")
 endif(VPIC_PRINT_MORE_DIGITS)
 
-if(GLOBAL_ID)
-  add_definitions(-DVPIC_GLOBAL_ID)
-  set(VPIC_CXX_FLAGS "${VPIC_CXX_FLAGS} -DVPIC_GLOBAL_ID")
+if(GLOBAL_PARTICLE_ID)
+  add_definitions(-DVPIC_GLOBAL_PARTICLE_ID)
+  set(VPIC_CXX_FLAGS "${VPIC_CXX_FLAGS} -DVPIC_GLOBAL_PARTICLE_ID")
 endif()
 
 #------------------------------------------------------------------------------#

--- a/sample/harris_selective_dump
+++ b/sample/harris_selective_dump
@@ -390,7 +390,7 @@ begin_diagnostics {
      //};
      //my_predicate = nullptr;
 
-     #ifndef VPIC_GLOBAL_ID
+     #ifndef VPIC_GLOBAL_PARTICLE_ID
      #  error "To use predicates based on ID you need to compile VPIC with GLOBAL_ID=ON"
      #endif
      dump_particles_predicate("electron","eparticle",

--- a/sample/harris_selective_dump
+++ b/sample/harris_selective_dump
@@ -390,6 +390,9 @@ begin_diagnostics {
      //};
      //my_predicate = nullptr;
 
+     #ifndef VPIC_GLOBAL_ID
+     #  error "To use predicates based on ID you need to compile VPIC with GLOBAL_ID=ON"
+     #endif
      dump_particles_predicate("electron","eparticle",
              1, //ftag?
              my_predicate );

--- a/src/boundary/boundary_p.cc
+++ b/src/boundary/boundary_p.cc
@@ -238,7 +238,7 @@ boundary_p( particle_bc_t       * RESTRICT pbc_list,
       const int32_t sp_id = sp->id;
 
       particle_t * RESTRICT ALIGNED(128) p0 = sp->p;
-      #ifdef VPIC_GLOBAL_ID
+      #ifdef VPIC_GLOBAL_PARTICLE_ID
       size_t* RESTRICT ALIGNED(128) p_id = sp->p_id;
       #endif
 
@@ -310,7 +310,7 @@ boundary_p( particle_bc_t       * RESTRICT pbc_list,
 
           #endif
 
-          #ifdef VPIC_GLOBAL_ID
+          #ifdef VPIC_GLOBAL_PARTICLE_ID
           // Send global id too
           pi->global_particle_id = p_id[i];
           #endif
@@ -381,7 +381,7 @@ boundary_p( particle_bc_t       * RESTRICT pbc_list,
 
         #endif
 
-        #ifdef VPIC_GLOBAL_ID
+        #ifdef VPIC_GLOBAL_PARTICLE_ID
         p_id[i] = p_id[np];    /* keep p_id[] in sync with p[] */
         #endif
       }
@@ -486,7 +486,7 @@ boundary_p( particle_bc_t       * RESTRICT pbc_list,
     {
       particle_mover_t * new_pm;
       particle_t       * new_p;
-      #ifdef VPIC_GLOBAL_ID
+      #ifdef VPIC_GLOBAL_PARTICLE_ID
       size_t           * new_p_id;
       #endif
 
@@ -510,7 +510,7 @@ boundary_p( particle_bc_t       * RESTRICT pbc_list,
 
         FREE_ALIGNED( sp->p );
 
-        #ifdef VPIC_GLOBAL_ID
+        #ifdef VPIC_GLOBAL_PARTICLE_ID
         /* changes made to p[] must be mirrored in p_id[] */
         MALLOC_ALIGNED( new_p_id, n, 128 );
 
@@ -547,7 +547,7 @@ boundary_p( particle_bc_t       * RESTRICT pbc_list,
 
         FREE_ALIGNED( sp->p );
 
-        #ifdef VPIC_GLOBAL_ID
+        #ifdef VPIC_GLOBAL_PARTICLE_ID
         /* changes made to p[] must be mirrored in p_id[] */
         MALLOC_ALIGNED( new_p_id, n, 128 );
 
@@ -596,7 +596,7 @@ boundary_p( particle_bc_t       * RESTRICT pbc_list,
 
     particle_t       * RESTRICT ALIGNED(32) sp_p [ MAX_SP ];
     particle_mover_t * RESTRICT ALIGNED(32) sp_pm[ MAX_SP ];
-    #ifdef VPIC_GLOBAL_ID
+    #ifdef VPIC_GLOBAL_PARTICLE_ID
     size_t           * RESTRICT ALIGNED(32) sp_p_id[ MAX_SP ];
     #endif
 
@@ -622,7 +622,7 @@ boundary_p( particle_bc_t       * RESTRICT pbc_list,
       sp_np[ sp->id ] = sp->np;
       sp_nm[ sp->id ] = sp->nm;
 
-      #ifdef VPIC_GLOBAL_ID
+      #ifdef VPIC_GLOBAL_PARTICLE_ID
       sp_p_id[ sp->id ] = sp->p_id;
       #endif
 
@@ -645,7 +645,7 @@ boundary_p( particle_bc_t       * RESTRICT pbc_list,
       particle_t                * RESTRICT ALIGNED(32) p;
       particle_mover_t          * RESTRICT ALIGNED(16) pm;
       const particle_injector_t * RESTRICT ALIGNED(16) pi;
-      #ifdef VPIC_GLOBAL_ID
+      #ifdef VPIC_GLOBAL_PARTICLE_ID
       size_t                    * RESTRICT ALIGNED(32) p_id;
       #endif
 
@@ -697,7 +697,7 @@ boundary_p( particle_bc_t       * RESTRICT pbc_list,
 
         p = sp_p[id];
         np = sp_np[id];
-        #ifdef VPIC_GLOBAL_ID
+        #ifdef VPIC_GLOBAL_PARTICLE_ID
         p_id = sp_p_id[id];
         #endif
 
@@ -732,7 +732,7 @@ boundary_p( particle_bc_t       * RESTRICT pbc_list,
 
         #endif
 
-        #ifdef VPIC_GLOBAL_ID
+        #ifdef VPIC_GLOBAL_PARTICLE_ID
         p_id[np] = pi->global_particle_id;
 
         std::cout << "Recving particle with global_id " << pi->global_particle_id << " on rank " << _world_rank << std::endl;

--- a/src/boundary/boundary_p.cc
+++ b/src/boundary/boundary_p.cc
@@ -238,7 +238,9 @@ boundary_p( particle_bc_t       * RESTRICT pbc_list,
       const int32_t sp_id = sp->id;
 
       particle_t * RESTRICT ALIGNED(128) p0 = sp->p;
+      #ifdef VPIC_GLOBAL_ID
       size_t* RESTRICT ALIGNED(128) p_id = sp->p_id;
+      #endif
 
       int np = sp->np;
 
@@ -308,8 +310,10 @@ boundary_p( particle_bc_t       * RESTRICT pbc_list,
 
           #endif
 
+          #ifdef VPIC_GLOBAL_ID
           // Send global id too
           pi->global_particle_id = p_id[i];
+          #endif
 
           ( &pi->dx )[ axis[ face ] ] = dir[ face ];
           pi->i                       = nn - range[ face ];
@@ -377,7 +381,9 @@ boundary_p( particle_bc_t       * RESTRICT pbc_list,
 
         #endif
 
+        #ifdef VPIC_GLOBAL_ID
         p_id[i] = p_id[np];    /* keep p_id[] in sync with p[] */
+        #endif
       }
 
       sp->np = np;
@@ -480,7 +486,9 @@ boundary_p( particle_bc_t       * RESTRICT pbc_list,
     {
       particle_mover_t * new_pm;
       particle_t       * new_p;
+      #ifdef VPIC_GLOBAL_ID
       size_t           * new_p_id;
+      #endif
 
       n = sp->np + max_inj;
 
@@ -502,6 +510,7 @@ boundary_p( particle_bc_t       * RESTRICT pbc_list,
 
         FREE_ALIGNED( sp->p );
 
+        #ifdef VPIC_GLOBAL_ID
         /* changes made to p[] must be mirrored in p_id[] */
         MALLOC_ALIGNED( new_p_id, n, 128 );
 
@@ -509,8 +518,10 @@ boundary_p( particle_bc_t       * RESTRICT pbc_list,
 
         FREE_ALIGNED( sp->p_id );
 
-        sp->p      = new_p;
         sp->p_id   = new_p_id;
+        #endif
+
+        sp->p      = new_p;
         sp->max_np = n;
       }
 
@@ -536,6 +547,7 @@ boundary_p( particle_bc_t       * RESTRICT pbc_list,
 
         FREE_ALIGNED( sp->p );
 
+        #ifdef VPIC_GLOBAL_ID
         /* changes made to p[] must be mirrored in p_id[] */
         MALLOC_ALIGNED( new_p_id, n, 128 );
 
@@ -543,8 +555,10 @@ boundary_p( particle_bc_t       * RESTRICT pbc_list,
 
         FREE_ALIGNED( sp->p_id );
 
-        sp->p      = new_p;
         sp->p_id   = new_p_id;
+        #endif
+
+        sp->p      = new_p;
         sp->max_np = n;
       }
 
@@ -581,8 +595,10 @@ boundary_p( particle_bc_t       * RESTRICT pbc_list,
     // Unpack the species list for random acesss.
 
     particle_t       * RESTRICT ALIGNED(32) sp_p [ MAX_SP ];
-    size_t* RESTRICT ALIGNED(32) sp_p_id[ MAX_SP ];
     particle_mover_t * RESTRICT ALIGNED(32) sp_pm[ MAX_SP ];
+    #ifdef VPIC_GLOBAL_ID
+    size_t           * RESTRICT ALIGNED(32) sp_p_id[ MAX_SP ];
+    #endif
 
     float sp_q [ MAX_SP ];
     int   sp_np[ MAX_SP ];
@@ -601,11 +617,14 @@ boundary_p( particle_bc_t       * RESTRICT pbc_list,
     LIST_FOR_EACH( sp, sp_list )
     {
       sp_p[ sp->id ] = sp->p;
-      sp_p_id[ sp->id ] = sp->p_id;
       sp_pm[ sp->id ] = sp->pm;
       sp_q [ sp->id ] = sp->q;
       sp_np[ sp->id ] = sp->np;
       sp_nm[ sp->id ] = sp->nm;
+
+      #ifdef VPIC_GLOBAL_ID
+      sp_p_id[ sp->id ] = sp->p_id;
+      #endif
 
       #ifdef DISABLE_DYNAMIC_RESIZING
       sp_max_np[ sp->id ] = sp->max_np;
@@ -623,10 +642,12 @@ boundary_p( particle_bc_t       * RESTRICT pbc_list,
 
     do
     {
-      particle_t* RESTRICT ALIGNED(32) p;
-      size_t* RESTRICT ALIGNED(32) p_id;
-      particle_mover_t* RESTRICT ALIGNED(16) pm;
+      particle_t                * RESTRICT ALIGNED(32) p;
+      particle_mover_t          * RESTRICT ALIGNED(16) pm;
       const particle_injector_t * RESTRICT ALIGNED(16) pi;
+      #ifdef VPIC_GLOBAL_ID
+      size_t                    * RESTRICT ALIGNED(32) p_id;
+      #endif
 
       int np, nm, n, id;
 
@@ -675,8 +696,10 @@ boundary_p( particle_bc_t       * RESTRICT pbc_list,
         id = pi->sp_id;
 
         p = sp_p[id];
-        p_id = sp_p_id[id];
         np = sp_np[id];
+        #ifdef VPIC_GLOBAL_ID
+        p_id = sp_p_id[id];
+        #endif
 
         pm = sp_pm[id];
         nm = sp_nm[id];
@@ -709,9 +732,11 @@ boundary_p( particle_bc_t       * RESTRICT pbc_list,
 
         #endif
 
+        #ifdef VPIC_GLOBAL_ID
         p_id[np] = pi->global_particle_id;
 
         std::cout << "Recving particle with global_id " << pi->global_particle_id << " on rank " << _world_rank << std::endl;
+        #endif
 
         sp_np[id] = np + 1;
 

--- a/src/emitter/child_langmuir.cc
+++ b/src/emitter/child_langmuir.cc
@@ -43,7 +43,7 @@ emit_child_langmuir( child_langmuir_t * RESTRICT              cl,
   /**/  rng_t            * RESTRICT              rng = cl->rng;
 
   /**/  particle_t       * RESTRICT ALIGNED(128) p   = sp->p;
-  #ifdef VPIC_GLOBAL_ID
+  #ifdef VPIC_GLOBAL_PARTICLE_ID
   /**/  size_t           * RESTRICT ALIGNED(128) p_id = sp->p_id;
   #endif
   /**/  particle_mover_t * RESTRICT ALIGNED(128) pm  = sp->pm;
@@ -82,7 +82,7 @@ emit_child_langmuir( child_langmuir_t * RESTRICT              cl,
     // FIXME: COULD PROBABLY ACCELERATE BY GETTING RID OF SWITCH (USE
     // MAXWELLIAN_REFLUX TRICKS?)
 
-#ifdef VPIC_GLOBAL_ID
+#ifdef VPIC_GLOBAL_PARTICLE_ID
 #  define EMIT_PARTICLE_SET_ID p_id[np] = sp->generate_particle_id(np, sp->max_np);
 #else
 #  define EMIT_PARTICLE_SET_ID

--- a/src/emitter/child_langmuir.cc
+++ b/src/emitter/child_langmuir.cc
@@ -43,7 +43,9 @@ emit_child_langmuir( child_langmuir_t * RESTRICT              cl,
   /**/  rng_t            * RESTRICT              rng = cl->rng;
 
   /**/  particle_t       * RESTRICT ALIGNED(128) p   = sp->p;
+  #ifdef VPIC_GLOBAL_ID
   /**/  size_t           * RESTRICT ALIGNED(128) p_id = sp->p_id;
+  #endif
   /**/  particle_mover_t * RESTRICT ALIGNED(128) pm  = sp->pm;
   /**/  grid_t           * RESTRICT              g   = sp->g;
 
@@ -80,6 +82,12 @@ emit_child_langmuir( child_langmuir_t * RESTRICT              cl,
     // FIXME: COULD PROBABLY ACCELERATE BY GETTING RID OF SWITCH (USE
     // MAXWELLIAN_REFLUX TRICKS?)
 
+#ifdef VPIC_GLOBAL_ID
+#  define EMIT_PARTICLE_SET_ID p_id[np] = sp->generate_particle_id(np, sp->max_np);
+#else
+#  define EMIT_PARTICLE_SET_ID
+#endif
+
 #   define EMIT_PARTICLES(X,Y,Z,dir)                                    \
     w = fi[i].e##X;                                                     \
     if( dir qsp*w > thresh ) { /* This face can emit */                 \
@@ -100,7 +108,7 @@ emit_child_langmuir( child_langmuir_t * RESTRICT              cl,
         p[np].u##Y = u##Y;                                              \
         p[np].u##Z = u##Z;                                              \
         p[np].w    = w;                                                 \
-        p_id[np] = sp->generate_particle_id(np, sp->max_np);            \
+        EMIT_PARTICLE_SET_ID                                            \
         accumulate_rhob( f, p+np, g, -qsp );                            \
         np++;                                                           \
                                                                         \

--- a/src/species_advance/species_advance.cc
+++ b/src/species_advance/species_advance.cc
@@ -21,7 +21,7 @@ checkpt_species( const species_t * sp )
                 sp->np     * sizeof(particle_t),
                 sp->max_np * sizeof(particle_t), 1, 1, 128 );
 
-  #ifdef VPIC_GLOBAL_ID
+  #ifdef VPIC_GLOBAL_PARTICLE_ID
   // REVIEW: Does the ordering of checkpt_data calls matter?
   // RFB: Add checkpointing of particle list
   checkpt_data( sp->p_id,
@@ -44,8 +44,7 @@ restore_species( void )
   RESTORE( sp );
   RESTORE_STR( sp->name );
   sp->p  = (particle_t *)        restore_data();
-  #ifdef VPIC_GLOBAL_ID
-  // REVIEW: Does the ordering of restore_data calls matter? Does it have to match checkpt_data?
+  #ifdef VPIC_GLOBAL_PARTICLE_ID
   sp->p_id  = (size_t*)          restore_data();
   #endif
   sp->pm = (particle_mover_t *)  restore_data();
@@ -62,7 +61,7 @@ delete_species( species_t * sp )
   FREE_ALIGNED( sp->partition );
   FREE_ALIGNED( sp->pm );
   FREE_ALIGNED( sp->p );
-  #ifdef VPIC_GLOBAL_ID
+  #ifdef VPIC_GLOBAL_PARTICLE_ID
   FREE_ALIGNED( sp->p_id );
   #endif
   FREE( sp->name );
@@ -153,7 +152,7 @@ species( const char * name,
   sp->m = m;
 
   MALLOC_ALIGNED( sp->p, max_local_np, 128 );
-  #ifdef VPIC_GLOBAL_ID
+  #ifdef VPIC_GLOBAL_PARTICLE_ID
   MALLOC_ALIGNED( sp->p_id, max_local_np, 128 );
   #endif
   sp->max_np = max_local_np;

--- a/src/species_advance/species_advance.cc
+++ b/src/species_advance/species_advance.cc
@@ -21,14 +21,17 @@ checkpt_species( const species_t * sp )
                 sp->np     * sizeof(particle_t),
                 sp->max_np * sizeof(particle_t), 1, 1, 128 );
 
+  #ifdef VPIC_GLOBAL_ID
+  // REVIEW: Does the ordering of checkpt_data calls matter?
   // RFB: Add checkpointing of particle list
   checkpt_data( sp->p_id,
-                sp->np    *sizeof(size_t),
-                sp->max_np*sizeof(size_t), 1, 1, 128 );
+                sp->np     * sizeof(size_t),
+                sp->max_np * sizeof(size_t), 1, 1, 128 );
+  #endif
 
   checkpt_data( sp->pm,
-                sp->nm    *sizeof(particle_mover_t),
-                sp->max_nm*sizeof(particle_mover_t), 1, 1, 128 );
+                sp->nm     * sizeof(particle_mover_t),
+                sp->max_nm * sizeof(particle_mover_t), 1, 1, 128 );
   CHECKPT_ALIGNED( sp->partition, sp->g->nv+1, 128 );
   CHECKPT_PTR( sp->g );
   CHECKPT_PTR( sp->next );
@@ -41,7 +44,10 @@ restore_species( void )
   RESTORE( sp );
   RESTORE_STR( sp->name );
   sp->p  = (particle_t *)        restore_data();
+  #ifdef VPIC_GLOBAL_ID
+  // REVIEW: Does the ordering of restore_data calls matter? Does it have to match checkpt_data?
   sp->p_id  = (size_t*)          restore_data();
+  #endif
   sp->pm = (particle_mover_t *)  restore_data();
   RESTORE_ALIGNED( sp->partition );
   RESTORE_PTR( sp->g );
@@ -56,7 +62,9 @@ delete_species( species_t * sp )
   FREE_ALIGNED( sp->partition );
   FREE_ALIGNED( sp->pm );
   FREE_ALIGNED( sp->p );
+  #ifdef VPIC_GLOBAL_ID
   FREE_ALIGNED( sp->p_id );
+  #endif
   FREE( sp->name );
   FREE( sp );
 }
@@ -145,7 +153,9 @@ species( const char * name,
   sp->m = m;
 
   MALLOC_ALIGNED( sp->p, max_local_np, 128 );
+  #ifdef VPIC_GLOBAL_ID
   MALLOC_ALIGNED( sp->p_id, max_local_np, 128 );
+  #endif
   sp->max_np = max_local_np;
 
   MALLOC_ALIGNED( sp->pm, max_local_nm, 128 );

--- a/src/species_advance/species_advance_aos.h
+++ b/src/species_advance/species_advance_aos.h
@@ -51,7 +51,7 @@ typedef struct particle_injector {
   float w;                   // Particle weight (number of physical particles)
   float dispx, dispy, dispz; // Displacement of particle
   species_id sp_id;          // Species of particle
-#ifdef VPIC_GLOBAL_ID
+#ifdef VPIC_GLOBAL_PARTICLE_ID
   size_t global_particle_id;
 #endif
 } particle_injector_t;
@@ -64,7 +64,7 @@ class species_t {
 
         int np, max_np;                     // Number and max local particles
         particle_t * ALIGNED(128) p;        // Array of particles for the species
-        #ifdef VPIC_GLOBAL_ID
+        #ifdef VPIC_GLOBAL_PARTICLE_ID
         size_t* ALIGNED(128) p_id;          // Separate array of IDs
         #endif
 

--- a/src/species_advance/species_advance_aos.h
+++ b/src/species_advance/species_advance_aos.h
@@ -51,7 +51,9 @@ typedef struct particle_injector {
   float w;                   // Particle weight (number of physical particles)
   float dispx, dispy, dispz; // Displacement of particle
   species_id sp_id;          // Species of particle
+#ifdef VPIC_GLOBAL_ID
   size_t global_particle_id;
+#endif
 } particle_injector_t;
 
 class species_t {
@@ -62,7 +64,9 @@ class species_t {
 
         int np, max_np;                     // Number and max local particles
         particle_t * ALIGNED(128) p;        // Array of particles for the species
-        size_t* ALIGNED(128) p_id;          // Array of particles for the species
+        #ifdef VPIC_GLOBAL_ID
+        size_t* ALIGNED(128) p_id;          // Separate array of IDs
+        #endif
 
         int nm, max_nm;                     // Number and max local movers in use
         particle_mover_t * ALIGNED(128) pm; // Particle movers

--- a/src/species_advance/standard/pipeline/sort_p_pipeline.cc
+++ b/src/species_advance/standard/pipeline/sort_p_pipeline.cc
@@ -24,7 +24,7 @@
 // FIXME: HOOK UP IN-PLACE / OUT-PLACE OPTIONS AGAIN.
 
 //----------------------------------------------------------------------------//
-// 
+//
 //----------------------------------------------------------------------------//
 
 void
@@ -75,7 +75,7 @@ coarse_count_pipeline_scalar( sort_p_pipeline_args_t * args,
 }
 
 //----------------------------------------------------------------------------//
-// 
+//
 //----------------------------------------------------------------------------//
 
 void
@@ -85,7 +85,7 @@ coarse_sort_pipeline_scalar( sort_p_pipeline_args_t * args,
 {
   const particle_t * RESTRICT ALIGNED(128) p_src = args->p;
   /**/  particle_t * RESTRICT ALIGNED(128) p_dst = args->aux_p;
-  #ifdef VPIC_GLOBAL_ID
+  #ifdef VPIC_GLOBAL_PARTICLE_ID
   const size_t * RESTRICT ALIGNED(128) p_src_id = args->p_id;
   /**/  size_t * RESTRICT ALIGNED(128) p_dst_id = args->aux_p_id;
   #endif
@@ -126,25 +126,25 @@ coarse_sort_pipeline_scalar( sort_p_pipeline_args_t * args,
   {
     j = next[ V2P( p_src[i].i, n_subsort, vl, vh ) ]++;
 
-#   if defined( __SSE__ )
+     #if defined( __SSE__ )
 
     _mm_store_ps( &p_dst[j].dx, _mm_load_ps( &p_src[i].dx ) );
     _mm_store_ps( &p_dst[j].ux, _mm_load_ps( &p_src[i].ux ) );
 
-#   else
+    #else
 
     p_dst[j] = p_src[i];
 
-#   endif
+    #endif
 
-    #ifdef VPIC_GLOBAL_ID
+    #ifdef VPIC_GLOBAL_PARTICLE_ID
     p_dst_id[j] = p_src_id[i]; /* keep ids in sync with particles */
     #endif
   }
 }
 
 //----------------------------------------------------------------------------//
-// 
+//
 //----------------------------------------------------------------------------//
 
 void
@@ -154,7 +154,7 @@ subsort_pipeline_scalar( sort_p_pipeline_args_t * args,
 {
   const particle_t * RESTRICT ALIGNED(128) p_src = args->aux_p;
   /**/  particle_t * RESTRICT ALIGNED(128) p_dst = args->p;
-  #ifdef VPIC_GLOBAL_ID
+  #ifdef VPIC_GLOBAL_PARTICLE_ID
   const size_t * RESTRICT ALIGNED(128) p_src_id = args->aux_p_id;
   /**/  size_t * RESTRICT ALIGNED(128) p_dst_id = args->p_id;
   #endif
@@ -211,18 +211,18 @@ subsort_pipeline_scalar( sort_p_pipeline_args_t * args,
       v = p_src[i].i;
       j = next[v]++;
 
-#     if defined( __SSE__ )
+      #if defined( __SSE__ )
 
       _mm_store_ps( &p_dst[j].dx, _mm_load_ps( &p_src[i].dx ) );
       _mm_store_ps( &p_dst[j].ux, _mm_load_ps( &p_src[i].ux ) );
 
-#     else
+      #else
 
       p_dst[j] = p_src[i];
 
-#     endif
+      #endif
 
-      #ifdef VPIC_GLOBAL_ID
+      #ifdef VPIC_GLOBAL_PARTICLE_ID
       p_dst_id[j] = p_src_id[i]; /* keep ids in sync with particles */
       #endif
     }
@@ -230,7 +230,7 @@ subsort_pipeline_scalar( sort_p_pipeline_args_t * args,
 }
 
 //----------------------------------------------------------------------------//
-// 
+//
 //----------------------------------------------------------------------------//
 
 void
@@ -250,7 +250,7 @@ sort_p_pipeline( species_t * sp )
 
   particle_t * RESTRICT ALIGNED(128) p = sp->p;
   particle_t * RESTRICT ALIGNED(128) aux_p;
-  #ifdef VPIC_GLOBAL_ID
+  #ifdef VPIC_GLOBAL_PARTICLE_ID
   size_t * RESTRICT ALIGNED(128) p_id = sp->p_id;
   size_t * RESTRICT ALIGNED(128) aux_p_id;
   #endif
@@ -290,7 +290,7 @@ sort_p_pipeline( species_t * sp )
   // Ensure enough scratch space is allocated for the sorting.
   sz_scratch = ( sizeof( *p ) * n_particle      +
 		 128                            +
-  #ifdef VPIC_GLOBAL_ID
+  #ifdef VPIC_GLOBAL_PARTICLE_ID
                  sizeof( *p_id ) * n_particle   +
                  128                            +
   #endif
@@ -310,7 +310,7 @@ sort_p_pipeline( species_t * sp )
   aux_p            = ALIGN_PTR( particle_t, scratch,                          128 );
   next             = ALIGN_PTR( int,        aux_p + n_particle,               128 );
   coarse_partition = ALIGN_PTR( int,        next  + n_voxel,                  128 );
-  #ifdef VPIC_GLOBAL_ID
+  #ifdef VPIC_GLOBAL_PARTICLE_ID
   // REVIEW: is it ok to move aux_p_id to the end of the scratch space?
   aux_p_id         = ALIGN_PTR( size_t,     coarse_partition + n_particle,    128 );
   #endif
@@ -318,7 +318,7 @@ sort_p_pipeline( species_t * sp )
   // Setup pipeline arguments.
   args->p                = p;
   args->aux_p            = aux_p;
-  #ifdef VPIC_GLOBAL_ID
+  #ifdef VPIC_GLOBAL_PARTICLE_ID
   args->p_id             = p_id;
   args->aux_p_id         = aux_p_id;
   #endif
@@ -384,7 +384,7 @@ sort_p_pipeline( species_t * sp )
 
     args->p        = aux_p;
     args->aux_p    = p;
-    #ifdef VPIC_GLOBAL_ID
+    #ifdef VPIC_GLOBAL_PARTICLE_ID
     args->p_id     = aux_p_id;
     args->aux_p_id = p_id;
     #endif
@@ -403,7 +403,7 @@ sort_p_pipeline( species_t * sp )
     // TO MOVE SP->P AROUND AND DO MORE MALLOCS PER STEP I.E. HEAP
     // FRAGMENTATION, COULD AVOID THIS COPY.
     COPY( p, aux_p, n_particle );
-    #ifdef VPIC_GLOBAL_ID
+    #ifdef VPIC_GLOBAL_PARTICLE_ID
     COPY( p_id, aux_p_id, n_particle );
     #endif
   }

--- a/src/species_advance/standard/pipeline/sort_p_pipeline.cc
+++ b/src/species_advance/standard/pipeline/sort_p_pipeline.cc
@@ -85,8 +85,10 @@ coarse_sort_pipeline_scalar( sort_p_pipeline_args_t * args,
 {
   const particle_t * RESTRICT ALIGNED(128) p_src = args->p;
   /**/  particle_t * RESTRICT ALIGNED(128) p_dst = args->aux_p;
+  #ifdef VPIC_GLOBAL_ID
   const size_t * RESTRICT ALIGNED(128) p_src_id = args->p_id;
   /**/  size_t * RESTRICT ALIGNED(128) p_dst_id = args->aux_p_id;
+  #endif
 
   int i, i1;
   int n_subsort = args->n_subsort;
@@ -135,7 +137,9 @@ coarse_sort_pipeline_scalar( sort_p_pipeline_args_t * args,
 
 #   endif
 
+    #ifdef VPIC_GLOBAL_ID
     p_dst_id[j] = p_src_id[i]; /* keep ids in sync with particles */
+    #endif
   }
 }
 
@@ -150,8 +154,10 @@ subsort_pipeline_scalar( sort_p_pipeline_args_t * args,
 {
   const particle_t * RESTRICT ALIGNED(128) p_src = args->aux_p;
   /**/  particle_t * RESTRICT ALIGNED(128) p_dst = args->p;
+  #ifdef VPIC_GLOBAL_ID
   const size_t * RESTRICT ALIGNED(128) p_src_id = args->aux_p_id;
   /**/  size_t * RESTRICT ALIGNED(128) p_dst_id = args->p_id;
+  #endif
 
   int i0, i1, v0, v1, i, j, v, sum, count;
 
@@ -216,7 +222,9 @@ subsort_pipeline_scalar( sort_p_pipeline_args_t * args,
 
 #     endif
 
+      #ifdef VPIC_GLOBAL_ID
       p_dst_id[j] = p_src_id[i]; /* keep ids in sync with particles */
+      #endif
     }
   }
 }
@@ -242,8 +250,10 @@ sort_p_pipeline( species_t * sp )
 
   particle_t * RESTRICT ALIGNED(128) p = sp->p;
   particle_t * RESTRICT ALIGNED(128) aux_p;
+  #ifdef VPIC_GLOBAL_ID
   size_t * RESTRICT ALIGNED(128) p_id = sp->p_id;
   size_t * RESTRICT ALIGNED(128) aux_p_id;
+  #endif
 
   int n_particle = sp->np;
 
@@ -280,8 +290,10 @@ sort_p_pipeline( species_t * sp )
   // Ensure enough scratch space is allocated for the sorting.
   sz_scratch = ( sizeof( *p ) * n_particle      +
 		 128                            +
+  #ifdef VPIC_GLOBAL_ID
                  sizeof( *p_id ) * n_particle   +
                  128                            +
+  #endif
                  sizeof( *partition ) * n_voxel +
 		 128                            +
                  sizeof( *coarse_partition ) * ( cp_stride * n_pipeline + 1 ) );
@@ -295,16 +307,21 @@ sort_p_pipeline( species_t * sp )
     max_scratch = sz_scratch;
   }
 
-  aux_p            = ALIGN_PTR( particle_t, scratch,               128 );
-  aux_p_id         = ALIGN_PTR( size_t,     aux_p + n_particle,    128 );
-  next             = ALIGN_PTR( int,        aux_p_id + n_particle, 128 );
-  coarse_partition = ALIGN_PTR( int,        next  + n_voxel,       128 );
+  aux_p            = ALIGN_PTR( particle_t, scratch,                          128 );
+  next             = ALIGN_PTR( int,        aux_p + n_particle,               128 );
+  coarse_partition = ALIGN_PTR( int,        next  + n_voxel,                  128 );
+  #ifdef VPIC_GLOBAL_ID
+  // REVIEW: is it ok to move aux_p_id to the end of the scratch space?
+  aux_p_id         = ALIGN_PTR( size_t,     coarse_partition + n_particle,    128 );
+  #endif
 
   // Setup pipeline arguments.
   args->p                = p;
   args->aux_p            = aux_p;
+  #ifdef VPIC_GLOBAL_ID
   args->p_id             = p_id;
   args->aux_p_id         = aux_p_id;
+  #endif
   args->coarse_partition = coarse_partition;
   args->next             = next;
   args->partition        = partition;
@@ -367,8 +384,10 @@ sort_p_pipeline( species_t * sp )
 
     args->p        = aux_p;
     args->aux_p    = p;
+    #ifdef VPIC_GLOBAL_ID
     args->p_id     = aux_p_id;
     args->aux_p_id = p_id;
+    #endif
 
     subsort_pipeline_scalar( args, 0, 1 );
 
@@ -384,6 +403,8 @@ sort_p_pipeline( species_t * sp )
     // TO MOVE SP->P AROUND AND DO MORE MALLOCS PER STEP I.E. HEAP
     // FRAGMENTATION, COULD AVOID THIS COPY.
     COPY( p, aux_p, n_particle );
+    #ifdef VPIC_GLOBAL_ID
     COPY( p_id, aux_p_id, n_particle );
+    #endif
   }
 }

--- a/src/species_advance/standard/pipeline/spa_private.h
+++ b/src/species_advance/standard/pipeline/spa_private.h
@@ -221,7 +221,7 @@ typedef struct sort_p_pipeline_args
 {
   MEM_PTR( particle_t, 128 ) p;                // Particles (0:n-1)
   MEM_PTR( particle_t, 128 ) aux_p;            // Aux particle atorage (0:n-1)
-  #ifdef VPIC_GLOBAL_ID
+  #ifdef VPIC_GLOBAL_PARTICLE_ID
   MEM_PTR( size_t, 128) p_id;                  // Particle ids (0:n-1)
   MEM_PTR( size_t, 128 ) aux_p_id;             // Aux particle ids (0:n-1)
   #endif

--- a/src/species_advance/standard/pipeline/spa_private.h
+++ b/src/species_advance/standard/pipeline/spa_private.h
@@ -221,8 +221,10 @@ typedef struct sort_p_pipeline_args
 {
   MEM_PTR( particle_t, 128 ) p;                // Particles (0:n-1)
   MEM_PTR( particle_t, 128 ) aux_p;            // Aux particle atorage (0:n-1)
+  #ifdef VPIC_GLOBAL_ID
   MEM_PTR( size_t, 128) p_id;                  // Particle ids (0:n-1)
   MEM_PTR( size_t, 128 ) aux_p_id;             // Aux particle ids (0:n-1)
+  #endif
   MEM_PTR( int,        128 ) coarse_partition; // Coarse partition storage
   /**/ // (0:max_subsort-1,0:MAX_PIPELINE-1)
   MEM_PTR( int,        128 ) partition;        // Partitioning (0:n_voxel)

--- a/src/species_advance/standard/sort_p.cc
+++ b/src/species_advance/standard/sort_p.cc
@@ -21,6 +21,7 @@
 //
 //----------------------------------------------------------------------------//
 
+
 void
 sort_p( species_t * sp )
 {
@@ -30,7 +31,7 @@ sort_p( species_t * sp )
   sp->last_sorted = sp->g->step;
 
   particle_t * ALIGNED(128) p = sp->p;
-  #ifdef VPIC_GLOBAL_ID
+  #ifdef VPIC_GLOBAL_PARTICLE_ID
   size_t * ALIGNED(128) p_id = sp->p_id;
   #endif
 
@@ -95,7 +96,7 @@ sort_p( species_t * sp )
     in_p  = sp->p;
     out_p = new_p;
 
-    #ifdef VPIC_GLOBAL_ID
+    #ifdef VPIC_GLOBAL_PARTICLE_ID
     /**/  size_t*          ALIGNED(128) new_p_id;
     const size_t* RESTRICT ALIGNED( 32)  in_p_id;
     /**/  size_t* RESTRICT ALIGNED( 32) out_p_id;
@@ -108,7 +109,7 @@ sort_p( species_t * sp )
     for( i = 0; i < np; i++ )
     {
       out_p[ next[ in_p[i].i ] ] = in_p[i];
-      #ifdef VPIC_GLOBAL_ID
+      #ifdef VPIC_GLOBAL_PARTICLE_ID
       out_p_id[ next[ in_p[i].i ] ] = in_p_id[i];
       #endif
       next[ in_p[i].i ]++;  /* advance to next free slot for this cell */
@@ -117,7 +118,7 @@ sort_p( species_t * sp )
     FREE_ALIGNED( sp->p );
     sp->p = new_p;
 
-    #ifdef VPIC_GLOBAL_ID
+    #ifdef VPIC_GLOBAL_PARTICLE_ID
     FREE_ALIGNED( sp->p_id );
     sp->p_id = new_p_id;
     #endif
@@ -130,7 +131,7 @@ sort_p( species_t * sp )
     particle_t               save_p;
     particle_t * ALIGNED(32) src;
     particle_t * ALIGNED(32) dest;
-    #ifdef VPIC_GLOBAL_ID
+    #ifdef VPIC_GLOBAL_PARTICLE_ID
     size_t save_pid;
     size_t * ALIGNED(32) srcid;
     size_t * ALIGNED(32) destid;
@@ -147,14 +148,14 @@ sort_p( species_t * sp )
       else
       {
         src = &p[ next[i] ];
-        #ifdef VPIC_GLOBAL_ID
+        #ifdef VPIC_GLOBAL_PARTICLE_ID
         srcid = &p_id[ next[i] ];
         #endif
 
         for( ; ; )
         {
           dest = &p[ next[ src->i ] ];
-          #ifdef VPIC_GLOBAL_ID
+          #ifdef VPIC_GLOBAL_PARTICLE_ID
           destid = &p_id[ next[ src->i ] ];
           #endif
           next[ src->i ]++;  /* advance to next free slot for this cell */
@@ -164,7 +165,7 @@ sort_p( species_t * sp )
           save_p = *dest;
           *dest  = *src;
           *src   = save_p;
-          #ifdef VPIC_GLOBAL_ID
+          #ifdef VPIC_GLOBAL_PARTICLE_ID
           save_pid = *destid;
           *destid = *srcid;
           *srcid = save_pid;

--- a/src/species_advance/standard/sort_p.cc
+++ b/src/species_advance/standard/sort_p.cc
@@ -30,7 +30,9 @@ sort_p( species_t * sp )
   sp->last_sorted = sp->g->step;
 
   particle_t * ALIGNED(128) p = sp->p;
+  #ifdef VPIC_GLOBAL_ID
   size_t * ALIGNED(128) p_id = sp->p_id;
+  #endif
 
   const int np                = sp->np;
   const int nc                = sp->g->nv;
@@ -89,30 +91,36 @@ sort_p( species_t * sp )
     const particle_t * RESTRICT ALIGNED( 32)  in_p;
     /**/  particle_t * RESTRICT ALIGNED( 32) out_p;
 
+    MALLOC_ALIGNED( new_p, sp->max_np, 128 );
+    in_p  = sp->p;
+    out_p = new_p;
+
+    #ifdef VPIC_GLOBAL_ID
+    /**/  size_t*          ALIGNED(128) new_p_id;
     const size_t* RESTRICT ALIGNED( 32)  in_p_id;
     /**/  size_t* RESTRICT ALIGNED( 32) out_p_id;
 
-    MALLOC_ALIGNED( new_p, sp->max_np, 128 );
     MALLOC_ALIGNED( new_p_id, sp->max_np, 128 );
-
-    in_p  = sp->p;
     in_p_id  = sp->p_id;
-
-    out_p = new_p;
     out_p_id = new_p_id;
+    #endif
 
     for( i = 0; i < np; i++ )
     {
       out_p[ next[ in_p[i].i ] ] = in_p[i];
+      #ifdef VPIC_GLOBAL_ID
       out_p_id[ next[ in_p[i].i ] ] = in_p_id[i];
+      #endif
       next[ in_p[i].i ]++;  /* advance to next free slot for this cell */
     }
 
     FREE_ALIGNED( sp->p );
-    FREE_ALIGNED( sp->p_id );
-
     sp->p = new_p;
+
+    #ifdef VPIC_GLOBAL_ID
+    FREE_ALIGNED( sp->p_id );
     sp->p_id = new_p_id;
+    #endif
   }
 
   else
@@ -122,9 +130,11 @@ sort_p( species_t * sp )
     particle_t               save_p;
     particle_t * ALIGNED(32) src;
     particle_t * ALIGNED(32) dest;
+    #ifdef VPIC_GLOBAL_ID
     size_t save_pid;
     size_t * ALIGNED(32) srcid;
     size_t * ALIGNED(32) destid;
+    #endif
 
     i = 0;
     while( i < nc )
@@ -137,12 +147,16 @@ sort_p( species_t * sp )
       else
       {
         src = &p[ next[i] ];
+        #ifdef VPIC_GLOBAL_ID
         srcid = &p_id[ next[i] ];
+        #endif
 
         for( ; ; )
         {
           dest = &p[ next[ src->i ] ];
+          #ifdef VPIC_GLOBAL_ID
           destid = &p_id[ next[ src->i ] ];
+          #endif
           next[ src->i ]++;  /* advance to next free slot for this cell */
 
           if ( src == dest ) break;
@@ -150,9 +164,11 @@ sort_p( species_t * sp )
           save_p = *dest;
           *dest  = *src;
           *src   = save_p;
+          #ifdef VPIC_GLOBAL_ID
           save_pid = *destid;
           *destid = *srcid;
           *srcid = save_pid;
+          #endif
         }
       }
     }

--- a/src/vpic/advance.cc
+++ b/src/vpic/advance.cc
@@ -89,14 +89,18 @@ int vpic_simulation::advance(void) {
     int nm = sp->nm;
     particle_mover_t * RESTRICT ALIGNED(16)  pm = sp->pm + sp->nm - 1;
     particle_t * RESTRICT ALIGNED(128) p0 = sp->p;
+    #ifdef VPIC_GLOBAL_ID
     size_t * RESTRICT ALIGNED(128) p_id0 = sp->p_id;
+    #endif
     for (; nm; nm--, pm--) {
       int i = pm->i; // particle index we are removing
       p0[i].i >>= 3; // shift particle voxel down
       // accumulate the particle's charge to the mesh
       accumulate_rhob( field_array->f, p0+i, sp->g, sp->q );
       p0[i] = p0[sp->np-1];        // put the last particle into position i
+      #ifdef VPIC_GLOBAL_ID
       p_id0[i] = p_id0[sp->np-1];  // move the id up too
+      #endif
       sp->np--; // decrement the number of particles
     }
     sp->nm = 0;

--- a/src/vpic/advance.cc
+++ b/src/vpic/advance.cc
@@ -89,7 +89,7 @@ int vpic_simulation::advance(void) {
     int nm = sp->nm;
     particle_mover_t * RESTRICT ALIGNED(16)  pm = sp->pm + sp->nm - 1;
     particle_t * RESTRICT ALIGNED(128) p0 = sp->p;
-    #ifdef VPIC_GLOBAL_ID
+    #ifdef VPIC_GLOBAL_PARTICLE_ID
     size_t * RESTRICT ALIGNED(128) p_id0 = sp->p_id;
     #endif
     for (; nm; nm--, pm--) {
@@ -98,7 +98,7 @@ int vpic_simulation::advance(void) {
       // accumulate the particle's charge to the mesh
       accumulate_rhob( field_array->f, p0+i, sp->g, sp->q );
       p0[i] = p0[sp->np-1];        // put the last particle into position i
-      #ifdef VPIC_GLOBAL_ID
+      #ifdef VPIC_GLOBAL_PARTICLE_ID
       p_id0[i] = p_id0[sp->np-1];  // move the id up too
       #endif
       sp->np--; // decrement the number of particles

--- a/src/vpic/dump.cc
+++ b/src/vpic/dump.cc
@@ -32,7 +32,7 @@ int vpic_simulation::dump_cwd(char * dname, size_t size) {
  *****************************************************************************/
 
 // Do not even define these functions when there are no IDs so that input decks that rely on them don't compile.
-#ifdef VPIC_GLOBAL_ID
+#ifdef VPIC_GLOBAL_PARTICLE_ID
 int vpic_simulation::predicate_count(species_t* sp, std::function <bool (int)> f)
 {
     if (f != nullptr) return std::count_if( sp->p_id, sp->p_id + sp->np, f);

--- a/src/vpic/dump.cc
+++ b/src/vpic/dump.cc
@@ -31,6 +31,8 @@ int vpic_simulation::dump_cwd(char * dname, size_t size) {
  * ASCII dump IO
  *****************************************************************************/
 
+// Do not even define these functions when there are no IDs so that input decks that rely on them don't compile.
+#ifdef VPIC_GLOBAL_ID
 int vpic_simulation::predicate_count(species_t* sp, std::function <bool (int)> f)
 {
     if (f != nullptr) return std::count_if( sp->p_id, sp->p_id + sp->np, f);
@@ -69,7 +71,7 @@ void vpic_simulation::predicate_copy(species_t* sp_from, species_t* sp_to, std::
         std::cout << "copied " << next << std::endl;
     }
 }
-
+#endif
 
 void
 vpic_simulation::dump_energies( const char *fname,

--- a/src/vpic/misc.cc
+++ b/src/vpic/misc.cc
@@ -81,8 +81,10 @@ vpic_simulation::inject_particle( species_t * sp,
   p->uz = (float)uz;
   p->w  = w;
 
+  #ifdef VPIC_GLOBAL_ID
   // Set particle ID.
   sp->p_id[old_np] = sp->generate_particle_id( old_np, sp->max_np );
+  #endif
 
   if( update_rhob ) accumulate_rhob( field_array->f, p, grid, -sp->q );
 

--- a/src/vpic/misc.cc
+++ b/src/vpic/misc.cc
@@ -81,7 +81,7 @@ vpic_simulation::inject_particle( species_t * sp,
   p->uz = (float)uz;
   p->w  = w;
 
-  #ifdef VPIC_GLOBAL_ID
+  #ifdef VPIC_GLOBAL_PARTICLE_ID
   // Set particle ID.
   sp->p_id[old_np] = sp->generate_particle_id( old_np, sp->max_np );
   #endif

--- a/src/vpic/vpic.h
+++ b/src/vpic/vpic.h
@@ -141,6 +141,7 @@ public:
   int advance( void );
   void finalize( void );
 
+  #ifdef VPIC_GLOBAL_ID
   // TODO: move these somewhere more sensible
   int predicate_count(species_t* sp, std::function <bool (int)> f);
   int predicate_count(species_t* sp, std::function <bool (particle_t)> f);
@@ -148,6 +149,7 @@ public:
   // TOOD: those specialized in together should probably be wrapped in a class
   void predicate_copy(species_t* sp_from, species_t* sp_to, std::function <bool (int)> f);
   void predicate_copy(species_t* sp_from, species_t* sp_to, std::function <bool (particle_t)> f);
+  #endif
 
 protected:
 
@@ -263,7 +265,7 @@ protected:
                        int fname_tag = 1 );
 
 
-
+#ifdef VPIC_GLOBAL_ID
 // TODO: merge back down to one function
 // TODO: template out the functor type
 // TODO: find a way to specify if we want to predicate on particle array, or
@@ -358,6 +360,7 @@ protected:
 
       if( fileIO.close() ) ERROR(("File close failed on dump particles!!!"));
   }
+#endif
 
 
 
@@ -655,10 +658,12 @@ protected:
                        float ux, float uy, float uz, float w )
   {
     particle_t * RESTRICT p = sp->p + sp->np;
+    #ifdef VPIC_GLOBAL_ID
     size_t * RESTRICT p_id = sp->p_id + sp->np;
+    *p_id = sp->generate_particle_id( sp->np, sp->max_np );
+    #endif
     p->dx = dx; p->dy = dy; p->dz = dz; p->i = i;
     p->ux = ux; p->uy = uy; p->uz = uz; p->w = w;
-    *p_id = sp->generate_particle_id( sp->np, sp->max_np );
     sp->np++;
   }
 
@@ -672,11 +677,13 @@ protected:
                        int update_rhob )
   {
     particle_t       * RESTRICT p  = sp->p  + sp->np;
-    size_t           * RESTRICT p_id = sp->p_id + sp->np;
     particle_mover_t * RESTRICT pm = sp->pm + sp->nm;
+    #ifdef VPIC_GLOBAL_ID
+    size_t           * RESTRICT p_id = sp->p_id + sp->np;
+    *p_id = sp->generate_particle_id( sp->np, sp->max_np );
+    #endif
     p->dx = dx; p->dy = dy; p->dz = dz; p->i = i;
     p->ux = ux; p->uy = uy; p->uz = uz; p->w = w;
-    *p_id = sp->generate_particle_id( sp->np, sp->max_np );
     pm->dispx = dispx; pm->dispy = dispy; pm->dispz = dispz; pm->i = sp->np-1;
     if( update_rhob ) accumulate_rhob( field_array->f, p, grid, -sp->q );
     sp->nm += move_p( sp->p, pm, accumulator_array->a, grid, sp->q );

--- a/src/vpic/vpic.h
+++ b/src/vpic/vpic.h
@@ -141,7 +141,7 @@ public:
   int advance( void );
   void finalize( void );
 
-  #ifdef VPIC_GLOBAL_ID
+  #ifdef VPIC_GLOBAL_PARTICLE_ID
   // TODO: move these somewhere more sensible
   int predicate_count(species_t* sp, std::function <bool (int)> f);
   int predicate_count(species_t* sp, std::function <bool (particle_t)> f);
@@ -265,7 +265,7 @@ protected:
                        int fname_tag = 1 );
 
 
-#ifdef VPIC_GLOBAL_ID
+#ifdef VPIC_GLOBAL_PARTICLE_ID
 // TODO: merge back down to one function
 // TODO: template out the functor type
 // TODO: find a way to specify if we want to predicate on particle array, or
@@ -658,7 +658,7 @@ protected:
                        float ux, float uy, float uz, float w )
   {
     particle_t * RESTRICT p = sp->p + sp->np;
-    #ifdef VPIC_GLOBAL_ID
+    #ifdef VPIC_GLOBAL_PARTICLE_ID
     size_t * RESTRICT p_id = sp->p_id + sp->np;
     *p_id = sp->generate_particle_id( sp->np, sp->max_np );
     #endif
@@ -678,7 +678,7 @@ protected:
   {
     particle_t       * RESTRICT p  = sp->p  + sp->np;
     particle_mover_t * RESTRICT pm = sp->pm + sp->nm;
-    #ifdef VPIC_GLOBAL_ID
+    #ifdef VPIC_GLOBAL_PARTICLE_ID
     size_t           * RESTRICT p_id = sp->p_id + sp->np;
     *p_id = sp->generate_particle_id( sp->np, sp->max_np );
     #endif


### PR DESCRIPTION
unless VPIC_GLOBAL_ID is set (default OFF), no extra array of IDs is allocated and no extra run time effort is spent.