### PR TITLE
Make global_particle_id optional per species

### DIFF
--- a/sample/harris_selective_dump
+++ b/sample/harris_selective_dump
@@ -178,8 +178,9 @@ begin_initialization {
   // Allow 50% more local_particles in case of non-uniformity
   // VPIC will pick the number of movers to use for each species
   // Both species use out-of-place sorting
-  species_t * ion      = define_species( "ion",       ec, mi, 1.5*Ni/nproc(), -1, 40, 1 );
-  species_t * electron = define_species( "electron", -ec, me, 1.5*Ne/nproc(), -1, 20, 1 );
+  // Only electrons bother with particle_ids
+  species_t * ion      = define_species( "ion",       ec, mi, 1.5*Ni/nproc(), -1, 40, 1, 0 );
+  species_t * electron = define_species( "electron", -ec, me, 1.5*Ne/nproc(), -1, 20, 1, 1 );
 
   ///////////////////////////////////////////////////
   // Log diagnostic information about this simulation

--- a/sample/harris_selective_dump
+++ b/sample/harris_selective_dump
@@ -394,9 +394,14 @@ begin_diagnostics {
      #ifndef VPIC_GLOBAL_PARTICLE_ID
      #  error "To use predicates based on ID you need to compile VPIC with GLOBAL_ID=ON"
      #endif
-     dump_particles_predicate("electron","eparticle",
+
+     dump_particles_predicate("electron","elucky",
              1, //ftag?
              my_predicate );
+
+     // Do a regular dump too, that will be annotated with IDs for post processing
+     dump_particles("electron","eparticle");
+
   }
   if( should_dump(iparticle) ) dump_particles("ion",     "iparticle");
 

--- a/scripts/binary_reader/read_file.py
+++ b/scripts/binary_reader/read_file.py
@@ -80,6 +80,15 @@ elif header["dump_type"] == 2: # hydro
 
 elif header["dump_type"] == 3: #particles
     sys.stderr.write("Dealing with a particle file\n")
+
+    cur_byte = f.tell()
+    file_bytes = header["end_byte"] - cur_byte
+    particle_bytes = array_header["sizeof(p[0])"] * array_header["dim"][0]
+    print str(file_bytes)+" bytes unread"
+    print str(particle_bytes)+" bytes of that are particle buffer"
+    if file_bytes > particle_bytes:
+        print "There is "+str(file_bytes-particle_bytes)+" additional bytes at the end" 
+
     x,y,z, ux,uy,uz, w, voxel, ix,iy,iz, frac_x,frac_y,frac_z = get_next_particle(f, header)
     print "cell: "+str(ix)+" "+str(iy)+" "+str(iz)
     print "frac: "+str(frac_x)+" "+str(frac_y)+" "+str(frac_z)
@@ -87,10 +96,21 @@ elif header["dump_type"] == 3: #particles
     print "u:    "+str(ux)+" "+str(uy)+" "+str(uz)
     print "w:    "+str(w)
     print "voxel:"+str(voxel)
+    print ""
 
     # exhaust the file
     #for i in range(numpy.prod(array_header["dim"])-1):
     #    x,y,z, ux,uy,uz, w, voxel, ix,iy,iz, frac_x,frac_y,frac_z = get_next_particle(f, header)
+
+    if file_bytes > particle_bytes:
+        f.seek(cur_byte+particle_bytes, 0) # skip to end of particle buffer
+
+        id_array_header = read_array_header(f, header)
+        print "ID ARRAY HEADER: "
+        for k,v in sorted(id_array_header.items()):
+            print str(k)+": "+str(v)
+        print ""
+
 
 f.close()
 print ""

--- a/scripts/binary_reader/vpic_binary_reader.py
+++ b/scripts/binary_reader/vpic_binary_reader.py
@@ -137,7 +137,7 @@ def read_array_header(inputfile, header):
 
     cur_byte = f.tell()
     unread_byte = header["end_byte"] - cur_byte
-    no_fields = unread_byte / (elements * header["sizeof(float)"])
+    no_fields = unread_byte / (elements * array_header["sizeof(p[0])"])
 
     array_header["no_fields"] = no_fields
 

--- a/src/emitter/child_langmuir.cc
+++ b/src/emitter/child_langmuir.cc
@@ -44,6 +44,7 @@ emit_child_langmuir( child_langmuir_t * RESTRICT              cl,
 
   /**/  particle_t       * RESTRICT ALIGNED(128) p   = sp->p;
   #ifdef VPIC_GLOBAL_PARTICLE_ID
+  /**/  int                                      sp_has_ids = sp->has_ids;
   /**/  size_t           * RESTRICT ALIGNED(128) p_id = sp->p_id;
   #endif
   /**/  particle_mover_t * RESTRICT ALIGNED(128) pm  = sp->pm;
@@ -83,7 +84,7 @@ emit_child_langmuir( child_langmuir_t * RESTRICT              cl,
     // MAXWELLIAN_REFLUX TRICKS?)
 
 #ifdef VPIC_GLOBAL_PARTICLE_ID
-#  define EMIT_PARTICLE_SET_ID p_id[np] = sp->generate_particle_id(np, sp->max_np);
+#  define EMIT_PARTICLE_SET_ID if(sp_has_ids) {p_id[np] = sp->generate_particle_id(np, sp->max_np);}
 #else
 #  define EMIT_PARTICLE_SET_ID
 #endif

--- a/src/species_advance/species_advance.cc
+++ b/src/species_advance/species_advance.cc
@@ -53,7 +53,7 @@ restore_species( void )
   if(sp->has_ids) {
     sp->p_id  = (size_t*)        restore_data();
   } else {
-    sp->p_id  = (size_t*)        NULL;
+    sp->p_id  = (size_t*)        nullptr;
   }
   #endif
   return sp;
@@ -165,7 +165,7 @@ species( const char * name,
   if(has_ids) {
     MALLOC_ALIGNED( sp->p_id, max_local_np, 128 );
   } else {
-    sp->p_id = NULL; // if we ever dereference this NULL pointer, I screwed up
+    sp->p_id = nullptr; // if we ever dereference this NULL pointer, I screwed up
   }
   #endif
   sp->max_np = max_local_np;

--- a/src/species_advance/species_advance.cc
+++ b/src/species_advance/species_advance.cc
@@ -20,21 +20,22 @@ checkpt_species( const species_t * sp )
   checkpt_data( sp->p,
                 sp->np     * sizeof(particle_t),
                 sp->max_np * sizeof(particle_t), 1, 1, 128 );
-
-  #ifdef VPIC_GLOBAL_PARTICLE_ID
-  // REVIEW: Does the ordering of checkpt_data calls matter?
-  // RFB: Add checkpointing of particle list
-  checkpt_data( sp->p_id,
-                sp->np     * sizeof(size_t),
-                sp->max_np * sizeof(size_t), 1, 1, 128 );
-  #endif
-
   checkpt_data( sp->pm,
                 sp->nm     * sizeof(particle_mover_t),
                 sp->max_nm * sizeof(particle_mover_t), 1, 1, 128 );
   CHECKPT_ALIGNED( sp->partition, sp->g->nv+1, 128 );
   CHECKPT_PTR( sp->g );
   CHECKPT_PTR( sp->next );
+
+  #ifdef VPIC_GLOBAL_PARTICLE_ID
+  // RFB: Add checkpointing of particle list
+  if(sp->has_ids) {
+    checkpt_data( sp->p_id,
+                  sp->np     * sizeof(size_t),
+                  sp->max_np * sizeof(size_t), 1, 1, 128 );
+  }
+  #endif
+
 }
 
 species_t *
@@ -44,13 +45,17 @@ restore_species( void )
   RESTORE( sp );
   RESTORE_STR( sp->name );
   sp->p  = (particle_t *)        restore_data();
-  #ifdef VPIC_GLOBAL_PARTICLE_ID
-  sp->p_id  = (size_t*)          restore_data();
-  #endif
   sp->pm = (particle_mover_t *)  restore_data();
   RESTORE_ALIGNED( sp->partition );
   RESTORE_PTR( sp->g );
   RESTORE_PTR( sp->next );
+  #ifdef VPIC_GLOBAL_PARTICLE_ID
+  if(sp->has_ids) {
+    sp->p_id  = (size_t*)        restore_data();
+  } else {
+    sp->p_id  = (size_t*)        NULL;
+  }
+  #endif
   return sp;
 }
 
@@ -62,7 +67,9 @@ delete_species( species_t * sp )
   FREE_ALIGNED( sp->pm );
   FREE_ALIGNED( sp->p );
   #ifdef VPIC_GLOBAL_PARTICLE_ID
-  FREE_ALIGNED( sp->p_id );
+  if(sp->has_ids) {
+    FREE_ALIGNED( sp->p_id );
+  }
   #endif
   FREE( sp->name );
   FREE( sp );
@@ -130,6 +137,7 @@ species( const char * name,
          size_t max_local_nm,
          int sort_interval,
          int sort_out_of_place,
+         int has_ids,
          grid_t * g
          )
 {
@@ -153,7 +161,12 @@ species( const char * name,
 
   MALLOC_ALIGNED( sp->p, max_local_np, 128 );
   #ifdef VPIC_GLOBAL_PARTICLE_ID
-  MALLOC_ALIGNED( sp->p_id, max_local_np, 128 );
+  sp->has_ids = has_ids;
+  if(has_ids) {
+    MALLOC_ALIGNED( sp->p_id, max_local_np, 128 );
+  } else {
+    sp->p_id = NULL; // if we ever dereference this NULL pointer, I screwed up
+  }
   #endif
   sp->max_np = max_local_np;
 

--- a/src/species_advance/species_advance.h
+++ b/src/species_advance/species_advance.h
@@ -54,6 +54,7 @@ species( const char * name,
          size_t max_local_nm,
          int sort_interval,
          int sort_out_of_place,
+         int has_ids,
          grid_t * g
        );
 

--- a/src/species_advance/species_advance_aos.h
+++ b/src/species_advance/species_advance_aos.h
@@ -65,7 +65,6 @@ class species_t {
         int np, max_np;                     // Number and max local particles
         particle_t * ALIGNED(128) p;        // Array of particles for the species
         #ifdef VPIC_GLOBAL_PARTICLE_ID
-        // REVIEW: Should we duplicate np and max_np as ni and max_ni instead of a flag?
         int has_ids;                        // Does this species care about IDs?
         size_t* ALIGNED(128) p_id;          // Separate array of IDs
         #endif

--- a/src/species_advance/species_advance_aos.h
+++ b/src/species_advance/species_advance_aos.h
@@ -65,6 +65,8 @@ class species_t {
         int np, max_np;                     // Number and max local particles
         particle_t * ALIGNED(128) p;        // Array of particles for the species
         #ifdef VPIC_GLOBAL_PARTICLE_ID
+        // REVIEW: Should we duplicate np and max_np as ni and max_ni instead of a flag?
+        int has_ids;                        // Does this species care about IDs?
         size_t* ALIGNED(128) p_id;          // Separate array of IDs
         #endif
 

--- a/src/species_advance/standard/pipeline/sort_p_pipeline.cc
+++ b/src/species_advance/standard/pipeline/sort_p_pipeline.cc
@@ -314,12 +314,12 @@ sort_p_pipeline( species_t * sp )
     max_scratch = sz_scratch;
   }
 
-  aux_p            = ALIGN_PTR( particle_t, scratch,                          128 );
-  next             = ALIGN_PTR( int,        aux_p + n_particle,               128 );
-  coarse_partition = ALIGN_PTR( int,        next  + n_voxel,                  128 );
+  aux_p            = ALIGN_PTR( particle_t, scratch,                                     128);
+  next             = ALIGN_PTR( int,        aux_p + n_particle,                          128);
+  coarse_partition = ALIGN_PTR( int,        next  + n_voxel,                             128);
   #ifdef VPIC_GLOBAL_PARTICLE_ID
   if(has_ids) {
-    aux_p_id       = ALIGN_PTR( size_t,     coarse_partition + n_particle,    128 );
+    aux_p_id       = ALIGN_PTR( size_t,     coarse_partition + cp_stride*n_pipeline + 1, 128);
   } else {
     aux_p_id       = NULL;
   }

--- a/src/species_advance/standard/pipeline/sort_p_pipeline.cc
+++ b/src/species_advance/standard/pipeline/sort_p_pipeline.cc
@@ -86,6 +86,7 @@ coarse_sort_pipeline_scalar( sort_p_pipeline_args_t * args,
   const particle_t * RESTRICT ALIGNED(128) p_src = args->p;
   /**/  particle_t * RESTRICT ALIGNED(128) p_dst = args->aux_p;
   #ifdef VPIC_GLOBAL_PARTICLE_ID
+  const int has_ids = args->has_ids;
   const size_t * RESTRICT ALIGNED(128) p_src_id = args->p_id;
   /**/  size_t * RESTRICT ALIGNED(128) p_dst_id = args->aux_p_id;
   #endif
@@ -138,7 +139,9 @@ coarse_sort_pipeline_scalar( sort_p_pipeline_args_t * args,
     #endif
 
     #ifdef VPIC_GLOBAL_PARTICLE_ID
-    p_dst_id[j] = p_src_id[i]; /* keep ids in sync with particles */
+    if(has_ids) {
+      p_dst_id[j] = p_src_id[i]; /* keep ids in sync with particles */
+    }
     #endif
   }
 }
@@ -155,6 +158,7 @@ subsort_pipeline_scalar( sort_p_pipeline_args_t * args,
   const particle_t * RESTRICT ALIGNED(128) p_src = args->aux_p;
   /**/  particle_t * RESTRICT ALIGNED(128) p_dst = args->p;
   #ifdef VPIC_GLOBAL_PARTICLE_ID
+  const int has_ids                             = args->has_ids;
   const size_t * RESTRICT ALIGNED(128) p_src_id = args->aux_p_id;
   /**/  size_t * RESTRICT ALIGNED(128) p_dst_id = args->p_id;
   #endif
@@ -223,7 +227,9 @@ subsort_pipeline_scalar( sort_p_pipeline_args_t * args,
       #endif
 
       #ifdef VPIC_GLOBAL_PARTICLE_ID
-      p_dst_id[j] = p_src_id[i]; /* keep ids in sync with particles */
+      if(has_ids) {
+        p_dst_id[j] = p_src_id[i]; /* keep ids in sync with particles */
+      }
       #endif
     }
   }
@@ -251,6 +257,7 @@ sort_p_pipeline( species_t * sp )
   particle_t * RESTRICT ALIGNED(128) p = sp->p;
   particle_t * RESTRICT ALIGNED(128) aux_p;
   #ifdef VPIC_GLOBAL_PARTICLE_ID
+  const int has_ids = sp->has_ids;
   size_t * RESTRICT ALIGNED(128) p_id = sp->p_id;
   size_t * RESTRICT ALIGNED(128) aux_p_id;
   #endif
@@ -288,15 +295,15 @@ sort_p_pipeline( species_t * sp )
   DECLARE_ALIGNED_ARRAY( sort_p_pipeline_args_t, 128, args, 1 );
 
   // Ensure enough scratch space is allocated for the sorting.
-  sz_scratch = ( sizeof( *p ) * n_particle      +
-		 128                            +
+  sz_scratch = 0;
+  sz_scratch += sizeof( *p )         * n_particle + 128;
+  sz_scratch += sizeof( *partition ) * n_voxel    + 128;
+  sz_scratch += sizeof( *coarse_partition ) * ( cp_stride * n_pipeline + 1 );
   #ifdef VPIC_GLOBAL_PARTICLE_ID
-                 sizeof( *p_id ) * n_particle   +
-                 128                            +
+  if(has_ids) {
+    sz_scratch += sizeof( *p_id ) * n_particle + 128;
+  }
   #endif
-                 sizeof( *partition ) * n_voxel +
-		 128                            +
-                 sizeof( *coarse_partition ) * ( cp_stride * n_pipeline + 1 ) );
 
   if ( sz_scratch > max_scratch )
   {
@@ -311,16 +318,25 @@ sort_p_pipeline( species_t * sp )
   next             = ALIGN_PTR( int,        aux_p + n_particle,               128 );
   coarse_partition = ALIGN_PTR( int,        next  + n_voxel,                  128 );
   #ifdef VPIC_GLOBAL_PARTICLE_ID
-  // REVIEW: is it ok to move aux_p_id to the end of the scratch space?
-  aux_p_id         = ALIGN_PTR( size_t,     coarse_partition + n_particle,    128 );
+  if(has_ids) {
+    aux_p_id       = ALIGN_PTR( size_t,     coarse_partition + n_particle,    128 );
+  } else {
+    aux_p_id       = NULL;
+  }
   #endif
 
   // Setup pipeline arguments.
   args->p                = p;
   args->aux_p            = aux_p;
   #ifdef VPIC_GLOBAL_PARTICLE_ID
-  args->p_id             = p_id;
-  args->aux_p_id         = aux_p_id;
+  args->has_ids        = has_ids;
+  if(has_ids) {
+    args->p_id           = p_id;
+    args->aux_p_id       = aux_p_id;
+  } else {
+    args->p_id           = NULL;
+    args->aux_p_id       = NULL;
+  }
   #endif
   args->coarse_partition = coarse_partition;
   args->next             = next;
@@ -385,8 +401,14 @@ sort_p_pipeline( species_t * sp )
     args->p        = aux_p;
     args->aux_p    = p;
     #ifdef VPIC_GLOBAL_PARTICLE_ID
-    args->p_id     = aux_p_id;
-    args->aux_p_id = p_id;
+    args->has_ids = has_ids;
+    if(has_ids) {
+      args->p_id     = aux_p_id;
+      args->aux_p_id = p_id;
+    } else {
+      args->p_id     = NULL;
+      args->aux_p_id = NULL;
+    }
     #endif
 
     subsort_pipeline_scalar( args, 0, 1 );
@@ -404,7 +426,9 @@ sort_p_pipeline( species_t * sp )
     // FRAGMENTATION, COULD AVOID THIS COPY.
     COPY( p, aux_p, n_particle );
     #ifdef VPIC_GLOBAL_PARTICLE_ID
-    COPY( p_id, aux_p_id, n_particle );
+    if(has_ids) {
+      COPY( p_id, aux_p_id, n_particle );
+    }
     #endif
   }
 }

--- a/src/species_advance/standard/pipeline/spa_private.h
+++ b/src/species_advance/standard/pipeline/spa_private.h
@@ -233,7 +233,11 @@ typedef struct sort_p_pipeline_args
   int n_subsort; // Number of pipelines to be used for subsorts
   int vl, vh;    // Particles may be contained in voxels [vl,vh].
   int n_voxel;   // Number of voxels total (including ghosts)
+  #ifdef VPIC_GLOBAL_PARTICLE_ID
+  int has_ids; // Are IDs present that need to be shuffled as well
+  #endif
 
+  // REVIEW: should we increase that to 7 SIZEOF_MEM_PTR and 6 ints?
   PAD_STRUCT( 5*SIZEOF_MEM_PTR + 5*sizeof(int) )
 } sort_p_pipeline_args_t;
 

--- a/src/species_advance/standard/pipeline/spa_private.h
+++ b/src/species_advance/standard/pipeline/spa_private.h
@@ -237,8 +237,7 @@ typedef struct sort_p_pipeline_args
   int has_ids; // Are IDs present that need to be shuffled as well
   #endif
 
-  // REVIEW: should we increase that to 7 SIZEOF_MEM_PTR and 6 ints?
-  PAD_STRUCT( 5*SIZEOF_MEM_PTR + 5*sizeof(int) )
+  PAD_STRUCT( 7*SIZEOF_MEM_PTR + 6*sizeof(int) )
 } sort_p_pipeline_args_t;
 
 void

--- a/src/vpic/advance.cc
+++ b/src/vpic/advance.cc
@@ -90,6 +90,7 @@ int vpic_simulation::advance(void) {
     particle_mover_t * RESTRICT ALIGNED(16)  pm = sp->pm + sp->nm - 1;
     particle_t * RESTRICT ALIGNED(128) p0 = sp->p;
     #ifdef VPIC_GLOBAL_PARTICLE_ID
+    const int sp_has_ids = sp->has_ids;
     size_t * RESTRICT ALIGNED(128) p_id0 = sp->p_id;
     #endif
     for (; nm; nm--, pm--) {
@@ -99,7 +100,9 @@ int vpic_simulation::advance(void) {
       accumulate_rhob( field_array->f, p0+i, sp->g, sp->q );
       p0[i] = p0[sp->np-1];        // put the last particle into position i
       #ifdef VPIC_GLOBAL_PARTICLE_ID
-      p_id0[i] = p_id0[sp->np-1];  // move the id up too
+      if(sp_has_ids) {
+        p_id0[i] = p_id0[sp->np-1];  // move the id up too
+      }
       #endif
       sp->np--; // decrement the number of particles
     }

--- a/src/vpic/dump.cc
+++ b/src/vpic/dump.cc
@@ -368,6 +368,7 @@ vpic_simulation::dump_particles( const char *sp_name,
   sp->np     = sp_np;
   sp->max_np = sp_max_np;
 
+  #ifdef VPIC_GLOBAL_PARTICLE_ID
   // append ID array at the end of the file
   if(sp->has_ids) {
     dim[0] = sp->np;
@@ -375,6 +376,7 @@ vpic_simulation::dump_particles( const char *sp_name,
     // REVIEW: Do we have to do this write in batched of PBUF_SIZE as well?
     fileIO.write(sp->p_id, sp->np);
   }
+#endif
 
   if( fileIO.close() ) ERROR(("File close failed on dump particles!!!"));
 }

--- a/src/vpic/dump.cc
+++ b/src/vpic/dump.cc
@@ -373,7 +373,7 @@ vpic_simulation::dump_particles( const char *sp_name,
   if(sp->has_ids) {
     dim[0] = sp->np;
     WRITE_ARRAY_HEADER( sp->p_id, 1, dim, fileIO );
-    // REVIEW: Do we have to do this write in batched of PBUF_SIZE as well?
+    // Maybe do this write in batched of PBUF_SIZE as well?
     fileIO.write(sp->p_id, sp->np);
   }
 #endif

--- a/src/vpic/dump.cc
+++ b/src/vpic/dump.cc
@@ -35,8 +35,11 @@ int vpic_simulation::dump_cwd(char * dname, size_t size) {
 #ifdef VPIC_GLOBAL_PARTICLE_ID
 int vpic_simulation::predicate_count(species_t* sp, std::function <bool (int)> f)
 {
-    if (f != nullptr) return std::count_if( sp->p_id, sp->p_id + sp->np, f);
-    else return sp->np;
+    if ((f == nullptr) || (!sp->has_ids)) {
+      return sp->np;
+    } else {
+      return std::count_if( sp->p_id, sp->p_id + sp->np, f);
+    }
 }
 int vpic_simulation::predicate_count(species_t* sp, std::function <bool (particle_t)> f)
 {
@@ -51,7 +54,7 @@ void vpic_simulation::predicate_copy(species_t* sp_from, species_t* sp_to, std::
 }
 void vpic_simulation::predicate_copy(species_t* sp_from, species_t* sp_to, std::function <bool (int)> f)
 {
-    if (f != nullptr)
+    if ((f != nullptr) && (sp_from->has_ids) )
     {
         //std::copy_if( sp->p_id, sp->p_id + sp->np, _sp.p, f);
         // Manually loop over particles to do the 'cross copy' from p_id->p

--- a/src/vpic/misc.cc
+++ b/src/vpic/misc.cc
@@ -83,7 +83,9 @@ vpic_simulation::inject_particle( species_t * sp,
 
   #ifdef VPIC_GLOBAL_PARTICLE_ID
   // Set particle ID.
-  sp->p_id[old_np] = sp->generate_particle_id( old_np, sp->max_np );
+  if(sp->has_ids) {
+    sp->p_id[old_np] = sp->generate_particle_id( old_np, sp->max_np );
+  }
   #endif
 
   if( update_rhob ) accumulate_rhob( field_array->f, p, grid, -sp->q );

--- a/src/vpic/vpic.h
+++ b/src/vpic/vpic.h
@@ -362,7 +362,7 @@ protected:
       if(sp->has_ids) {
           dim[0] = count_true;
           WRITE_ARRAY_HEADER( sp->p_id, 1, dim, fileIO );
-          // REVIEW: Do we have to do this write in batches of PBUF_SIZE as well
+          // Maybe do this write in batches of PBUF_SIZE as well
           fileIO.write(_sp.p_id, count_true);
       }
 

--- a/src/vpic/vpic.h
+++ b/src/vpic/vpic.h
@@ -609,7 +609,13 @@ protected:
                   double max_local_np,
                   double max_local_nm,
                   double sort_interval,
-                  double sort_out_of_place ) {
+                  double sort_out_of_place,
+                  int has_ids=0 ) {
+    #ifndef VPIC_GLOBAL_PARTICLE_ID
+    if(has_ids != 0) {
+      ERROR(( "This species can not have particle IDs because you compiled without GLOBAL_PARTICLE_ID" ));
+    }
+    #endif
     // Compute a reasonble number of movers if user did not specify
     // Based on the twice the number of particles expected to hit the boundary
     // of a wpdt=0.2 / dx=lambda species in a 3x3x3 domain
@@ -621,7 +627,7 @@ protected:
     return append_species( species( name, (float)q, (float)m,
                                     (size_t)max_local_np, (size_t)max_local_nm,
                                     (int)sort_interval, (int)sort_out_of_place,
-                                    grid ), &species_list );
+                                    has_ids, grid ), &species_list );
   }
 
   inline species_t *
@@ -659,8 +665,10 @@ protected:
   {
     particle_t * RESTRICT p = sp->p + sp->np;
     #ifdef VPIC_GLOBAL_PARTICLE_ID
-    size_t * RESTRICT p_id = sp->p_id + sp->np;
-    *p_id = sp->generate_particle_id( sp->np, sp->max_np );
+    if(sp->has_ids) {
+      size_t * RESTRICT p_id = sp->p_id + sp->np;
+      *p_id = sp->generate_particle_id( sp->np, sp->max_np );
+    }
     #endif
     p->dx = dx; p->dy = dy; p->dz = dz; p->i = i;
     p->ux = ux; p->uy = uy; p->uz = uz; p->w = w;
@@ -679,8 +687,10 @@ protected:
     particle_t       * RESTRICT p  = sp->p  + sp->np;
     particle_mover_t * RESTRICT pm = sp->pm + sp->nm;
     #ifdef VPIC_GLOBAL_PARTICLE_ID
-    size_t           * RESTRICT p_id = sp->p_id + sp->np;
-    *p_id = sp->generate_particle_id( sp->np, sp->max_np );
+    if(sp->has_ids) {
+      size_t           * RESTRICT p_id = sp->p_id + sp->np;
+      *p_id = sp->generate_particle_id( sp->np, sp->max_np );
+    }
     #endif
     p->dx = dx; p->dy = dy; p->dz = dz; p->i = i;
     p->ux = ux; p->uy = uy; p->uz = uz; p->w = w;


### PR DESCRIPTION
when support for it has been compiled in. A bunch of pointer is always
there and several loops contain a branch inside incuring a run-time cost,
but the main allocation for the extra array containing the particle IDs
is avoided, reducing the memory pressure substantially if IDs are only
required on tracer species with few particles instead of all particles.

This attacks the next checkbox in issue #98 but is not ready to be
merged yet. This is a new attempt, same as PR #101 but with a sane parent.