### PR TITLE
Support for in situ time average of fields, take 2

### DIFF
--- a/src/vpic/dumpmacros.h
+++ b/src/vpic/dumpmacros.h
@@ -4,40 +4,40 @@
 /* FIXME: WHEN THESE MACROS WERE HOISTED AND VARIOUS HACKS DONE TO THEM
    THEY BECAME _VERY_ _DANGEROUS. */
 
-#define WRITE_HEADER_V0(dump_type,sp_id,q_m,fileIO) do { \
-    /* Binary compatibility information */               \
-    WRITE( char,      CHAR_BIT,               fileIO );  \
-    WRITE( char,      sizeof(short int),      fileIO );  \
-    WRITE( char,      sizeof(int),            fileIO );  \
-    WRITE( char,      sizeof(float),          fileIO );  \
-    WRITE( char,      sizeof(double),         fileIO );  \
-    WRITE( short int, 0xcafe,                 fileIO );  \
-    WRITE( int,       0xdeadbeef,             fileIO );  \
-    WRITE( float,     1.0,                    fileIO );  \
-    WRITE( double,    1.0,                    fileIO );  \
-    /* Dump type and header format version */            \
-    WRITE( int,       0 /* Version */,        fileIO );  \
-    WRITE( int,       dump_type,              fileIO );  \
-    /* High level information */                         \
-    WRITE( int,       step(),                 fileIO );  \
-    WRITE( int,       nxout,                  fileIO );  \
-    WRITE( int,       nyout,                  fileIO );  \
-    WRITE( int,       nzout,                  fileIO );  \
-    WRITE( float,     grid->dt,               fileIO );  \
-    WRITE( float,     dxout,                  fileIO );  \
-    WRITE( float,     dyout,                  fileIO );  \
-    WRITE( float,     dzout,                  fileIO );  \
-    WRITE( float,     grid->x0,               fileIO );  \
-    WRITE( float,     grid->y0,               fileIO );  \
-    WRITE( float,     grid->z0,               fileIO );  \
-    WRITE( float,     grid->cvac,             fileIO );  \
-    WRITE( float,     grid->eps0,             fileIO );  \
-    WRITE( float,     0 /* damp */,           fileIO );  \
-    WRITE( int,       rank(),                 fileIO );  \
-    WRITE( int,       nproc(),                fileIO );  \
-    /* Species parameters */                             \
-    WRITE( int,       sp_id,                  fileIO );  \
-    WRITE( float,     q_m,                    fileIO );  \
+#define WRITE_HEADER_V0(dump_type,sp_id,q_m,cstep,fileIO) do { \
+    /* Binary compatibility information */                     \
+    WRITE( char,      CHAR_BIT,               fileIO );        \
+    WRITE( char,      sizeof(short int),      fileIO );        \
+    WRITE( char,      sizeof(int),            fileIO );        \
+    WRITE( char,      sizeof(float),          fileIO );        \
+    WRITE( char,      sizeof(double),         fileIO );        \
+    WRITE( short int, 0xcafe,                 fileIO );        \
+    WRITE( int,       0xdeadbeef,             fileIO );        \
+    WRITE( float,     1.0,                    fileIO );        \
+    WRITE( double,    1.0,                    fileIO );        \
+    /* Dump type and header format version */                  \
+    WRITE( int,       0 /* Version */,        fileIO );        \
+    WRITE( int,       dump_type,              fileIO );        \
+    /* High level information */                               \
+    WRITE( int,       cstep,                  fileIO );        \
+    WRITE( int,       nxout,                  fileIO );        \
+    WRITE( int,       nyout,                  fileIO );        \
+    WRITE( int,       nzout,                  fileIO );        \
+    WRITE( float,     grid->dt,               fileIO );        \
+    WRITE( float,     dxout,                  fileIO );        \
+    WRITE( float,     dyout,                  fileIO );        \
+    WRITE( float,     dzout,                  fileIO );        \
+    WRITE( float,     grid->x0,               fileIO );        \
+    WRITE( float,     grid->y0,               fileIO );        \
+    WRITE( float,     grid->z0,               fileIO );        \
+    WRITE( float,     grid->cvac,             fileIO );        \
+    WRITE( float,     grid->eps0,             fileIO );        \
+    WRITE( float,     0 /* damp */,           fileIO );        \
+    WRITE( int,       rank(),                 fileIO );        \
+    WRITE( int,       nproc(),                fileIO );        \
+    /* Species parameters */                                   \
+    WRITE( int,       sp_id,                  fileIO );        \
+    WRITE( float,     q_m,                    fileIO );        \
   } while(0)
  
 // Note dim _MUST_ be a pointer to an int

--- a/src/vpic/vpic.h
+++ b/src/vpic/vpic.h
@@ -36,19 +36,19 @@
 
 typedef FileIO FILETYPE;
 
-const uint32_t all			(0xffffffff);
-const uint32_t electric		(1<<0 | 1<<1 | 1<<2);
-const uint32_t div_e_err	(1<<3);
-const uint32_t magnetic		(1<<4 | 1<<5 | 1<<6);
-const uint32_t div_b_err	(1<<7);
-const uint32_t tca			(1<<8 | 1<<9 | 1<<10);
-const uint32_t rhob			(1<<11);
-const uint32_t current		(1<<12 | 1<<13 | 1<<14);
-const uint32_t rhof			(1<<15);
-const uint32_t emat			(1<<16 | 1<<17 | 1<<18);
-const uint32_t nmat			(1<<19);
-const uint32_t fmat			(1<<20 | 1<<21 | 1<<22);
-const uint32_t cmat			(1<<23);
+const uint32_t all                      (0xffffffff);
+const uint32_t electric         (1<<0 | 1<<1 | 1<<2);
+const uint32_t div_e_err        (1<<3);
+const uint32_t magnetic         (1<<4 | 1<<5 | 1<<6);
+const uint32_t div_b_err        (1<<7);
+const uint32_t tca                      (1<<8 | 1<<9 | 1<<10);
+const uint32_t rhob                     (1<<11);
+const uint32_t current          (1<<12 | 1<<13 | 1<<14);
+const uint32_t rhof                     (1<<15);
+const uint32_t emat                     (1<<16 | 1<<17 | 1<<18);
+const uint32_t nmat                     (1<<19);
+const uint32_t fmat                     (1<<20 | 1<<21 | 1<<22);
+const uint32_t cmat                     (1<<23);
 
 const size_t total_field_variables(24);
 const size_t total_field_groups(12); // this counts vectors, tensors etc...
@@ -56,21 +56,21 @@ const size_t total_field_groups(12); // this counts vectors, tensors etc...
 const size_t field_indeces[12] = { 0, 3, 4, 7, 8, 11, 12, 15, 16, 19, 20, 23 };
 
 struct FieldInfo {
-	char name[128];
-	char degree[128];
-	char elements[128];
-	char type[128];
-	size_t size;
+        char name[128];
+        char degree[128];
+        char elements[128];
+        char type[128];
+        size_t size;
 }; // struct FieldInfo
 
-const uint32_t current_density	(1<<0 | 1<<1 | 1<<2);
-const uint32_t charge_density	(1<<3);
-const uint32_t momentum_density	(1<<4 | 1<<5 | 1<<6);
-const uint32_t ke_density		(1<<7);
-const uint32_t stress_tensor	(1<<8 | 1<<9 | 1<<10 | 1<<11 | 1<<12 | 1<<13);
+const uint32_t current_density  (1<<0 | 1<<1 | 1<<2);
+const uint32_t charge_density   (1<<3);
+const uint32_t momentum_density (1<<4 | 1<<5 | 1<<6);
+const uint32_t ke_density               (1<<7);
+const uint32_t stress_tensor    (1<<8 | 1<<9 | 1<<10 | 1<<11 | 1<<12 | 1<<13);
 /* May want to use these instead
-const uint32_t stress_diagonal 		(1<<8 | 1<<9 | 1<<10);
-const uint32_t stress_offdiagonal	(1<<11 | 1<<12 | 1<<13);
+const uint32_t stress_diagonal          (1<<8 | 1<<9 | 1<<10);
+const uint32_t stress_offdiagonal       (1<<11 | 1<<12 | 1<<13);
 */
 
 const size_t total_hydro_variables(14);
@@ -79,11 +79,11 @@ const size_t total_hydro_groups(5); // this counts vectors, tensors etc...
 const size_t hydro_indeces[5] = { 0, 3, 4, 7, 8 };
 
 struct HydroInfo {
-	char name[128];
-	char degree[128];
-	char elements[128];
-	char type[128];
-	size_t size;
+        char name[128];
+        char degree[128];
+        char elements[128];
+        char type[128];
+        size_t size;
 }; // struct FieldInfo
 
 /*----------------------------------------------------------------------------
@@ -233,10 +233,15 @@ protected:
 
   // Binary dumps
   void dump_grid( const char *fbase );
-  void dump_fields( const char *fbase, int fname_tag = 1 );
-  void dump_hydro( const char *sp_name, const char *fbase,
-                   int fname_tag = 1 );
-  void dump_particles( const char *sp_name, const char *fbase,
+  void dump_fields( const char *fbase,
+		    int fname_tag = 1,
+		    field_t *f = NULL );
+  void dump_hydro( const char *sp_name,
+		   const char *fbase,
+                   int fname_tag = 1,
+		   hydro_t *h = NULL );
+  void dump_particles( const char *sp_name,
+		       const char *fbase,
                        int fname_tag = 1 );
 
   // convenience functions for simlog output
@@ -245,14 +250,19 @@ protected:
 
   void print_hashed_comment(FileIO & fileIO, const char * comment);
   void global_header(const char * base,
-  	std::vector<DumpParameters *> dumpParams);
+        std::vector<DumpParameters *> dumpParams);
 
   void field_header(const char * fbase, DumpParameters & dumpParams);
   void hydro_header(const char * speciesname, const char * hbase,
     DumpParameters & dumpParams);
 
-  void field_dump(DumpParameters & dumpParams);
-  void hydro_dump(const char * speciesname, DumpParameters & dumpParams);
+  void field_dump( DumpParameters & dumpParams,
+		   field_t *f = NULL,
+                   int64_t userStep = -1 );
+  void hydro_dump( const char *speciesname,
+		   DumpParameters & dumpParams,
+		   hydro_t *h = NULL,
+                   int64_t userStep = -1 );
 
   ///////////////////
   // Useful accessors
@@ -346,7 +356,7 @@ protected:
                         double xh,  double yh,  double zh,
                         double gnx, double gny, double gnz,
                         double gpx, double gpy, double gpz ) {
-	px = size_t(gpx); py = size_t(gpy); pz = size_t(gpz);
+        px = size_t(gpx); py = size_t(gpy); pz = size_t(gpz);
     partition_periodic_box( grid, xl, yl, zl, xh, yh, zh,
                             (int)gnx, (int)gny, (int)gnz,
                             (int)gpx, (int)gpy, (int)gpz );
@@ -357,7 +367,7 @@ protected:
                          double xh,  double yh,  double zh,
                          double gnx, double gny, double gnz,
                          double gpx, double gpy, double gpz, int pbc ) {
-	px = size_t(gpx); py = size_t(gpy); pz = size_t(gpz);
+        px = size_t(gpx); py = size_t(gpy); pz = size_t(gpz);
     partition_absorbing_box( grid, xl, yl, zl, xh, yh, zh,
                              (int)gnx, (int)gny, (int)gnz,
                              (int)gpx, (int)gpy, (int)gpz,
@@ -369,7 +379,7 @@ protected:
                           double xh,  double yh,  double zh,
                           double gnx, double gny, double gnz,
                           double gpx, double gpy, double gpz ) {
-	px = size_t(gpx); py = size_t(gpy); pz = size_t(gpz);
+        px = size_t(gpx); py = size_t(gpy); pz = size_t(gpz);
     partition_metal_box( grid, xl, yl, zl, xh, yh, zh,
                          (int)gnx, (int)gny, (int)gnz,
                          (int)gpx, (int)gpy, (int)gpz );
@@ -419,7 +429,7 @@ protected:
                    double epsx,        double epsy,       double epsz,
                    double mux,         double muy,        double muz,
                    double sigmax,      double sigmay,     double sigmaz,
-		   double zetax = 0 ,  double zetay = 0,  double zetaz = 0 ) {
+                   double zetax = 0 ,  double zetay = 0,  double zetaz = 0 ) {
     return append_material( material( name,
                                       epsx,   epsy,   epsz,
                                       mux,    muy,    muz,
@@ -646,7 +656,7 @@ protected:
 
   // Compute the Courant length on a regular mesh
   inline double courant_length( double lx, double ly, double lz,
-				double nx, double ny, double nz ) {
+                                double nx, double ny, double nz ) {
     double w0, w1 = 0;
     if( nx>1 ) w0 = nx/lx, w1 += w0*w0;
     if( ny>1 ) w0 = ny/ly, w1 += w0*w0;


### PR DESCRIPTION
Added changes to src/vpic/dump.cc and src/vpic/vpic.h originally implemented by Brian Albright to allow passing of the field to be dumped via an optional argument to relevant functions. The use case for this is to allow creation of a separate field to hold a time average of a given field which can then be time averaged in situ instead of dumping the field at a higher frequency and then performing the time average as a post-processing step. This greatly reduces the amount of IO which needs to be performed and the number of file system inodes that need to be used for large scale runs performed by some users. Use of an optional argument to the function allows for backward compatibility of existing input decks.

If at first you do not succeed, try, try again.
