### PR TITLE
This commit changes the semantics for lost movers, to avoid a segfault

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,8 @@ option(ENABLE_OPENSSL "Enable OpenSSL support for checksums" OFF)
 
 option(DISABLE_DYNAMIC_RESIZING "Prevent particle arrays from dynamically resizing during a run" OFF)
 
+option(EXIT_ON_LOST_MOVER "EXIT if we ruin out of mover space during the particle push (the default is WARN)" OFF)
+
 # option to set minimum number of particles
 set(SET_MIN_NUM_PARTICLES AUTO CACHE STRING "Select minimum number of particles to use, if using dynamic particle array resizing")
 
@@ -116,6 +118,14 @@ endif("${CMAKE_BUILD_TYPE}" STREQUAL "RelWithDebInfo")
 
 string(REPLACE ";" " " string_libraries "${MPI_CXX_LIBRARIES} ${MPI_C_LIBRARIES}")
 set(VPIC_CXX_LIBRARIES "${string_libraries}")
+
+if(DISABLE_DYNAMIC_RESIZING)
+  add_definitions(-DDISABLE_DYNAMIC_RESIZING)
+endif(DISABLE_DYNAMIC_RESIZING)
+
+if(EXIT_ON_LOST_MOVER)
+    add_definitions(-DEXIT_ON_LOST_MOVER)
+endif(EXIT_ON_LOST_MOVER)
 
 if(DISABLE_DYNAMIC_RESIZING)
   add_definitions(-DDISABLE_DYNAMIC_RESIZING)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,7 +88,7 @@ option(ENABLE_OPENSSL "Enable OpenSSL support for checksums" OFF)
 
 option(DISABLE_DYNAMIC_RESIZING "Prevent particle arrays from dynamically resizing during a run" OFF)
 
-option(EXIT_ON_LOST_MOVER "EXIT if we ruin out of mover space during the particle push (the default is WARN)" OFF)
+option(EXIT_ON_LOST_MOVER "EXIT if we run out of mover space during the particle push (the default is WARN)" OFF)
 
 # option to set minimum number of particles
 set(SET_MIN_NUM_PARTICLES AUTO CACHE STRING "Select minimum number of particles to use, if using dynamic particle array resizing")
@@ -118,10 +118,6 @@ endif("${CMAKE_BUILD_TYPE}" STREQUAL "RelWithDebInfo")
 
 string(REPLACE ";" " " string_libraries "${MPI_CXX_LIBRARIES} ${MPI_C_LIBRARIES}")
 set(VPIC_CXX_LIBRARIES "${string_libraries}")
-
-if(DISABLE_DYNAMIC_RESIZING)
-  add_definitions(-DDISABLE_DYNAMIC_RESIZING)
-endif(DISABLE_DYNAMIC_RESIZING)
 
 if(EXIT_ON_LOST_MOVER)
     add_definitions(-DEXIT_ON_LOST_MOVER)

--- a/src/species_advance/standard/pipeline/advance_p_pipeline.cc
+++ b/src/species_advance/standard/pipeline/advance_p_pipeline.cc
@@ -228,6 +228,11 @@ advance_p_pipeline_scalar( advance_p_pipeline_args_t * args,
         else
         {
           itmp++;                               // Unlikely
+
+          // Also undo the shift that move_p did, to keep p->i in a valid range
+          // If we got here, we're running the risk of ruining the physics of
+          // the simulation. Take the mover warning very seriously.
+          p->i = p->i >> 3;
         }
       }
     }
@@ -307,10 +312,13 @@ advance_p_pipeline( species_t * RESTRICT sp,
   {
     if ( args->seg[rank].n_ignored )
     {
-      WARNING( ( "Pipeline %i (species = %s) ran out of storage for %i movers.",
-                 rank,
-                 sp->name,
-                 args->seg[rank].n_ignored ) );
+        // If you see this warning, particles are essentially being held at the
+        // boundary instead of finishing their move. They are now in the wrong
+        // place and have not deposited correct currents....
+        WARNING( ( "Pipeline %i (species = %s) ran out of storage for %i movers.  This is an extremely serious problem that affects the physics of your run.",
+                    rank,
+                    sp->name,
+                    args->seg[rank].n_ignored ) );
     }
 
     if ( sp->pm + sp->nm != args->seg[rank].pm )

--- a/src/species_advance/standard/pipeline/advance_p_pipeline.cc
+++ b/src/species_advance/standard/pipeline/advance_p_pipeline.cc
@@ -312,6 +312,12 @@ advance_p_pipeline( species_t * RESTRICT sp,
   {
     if ( args->seg[rank].n_ignored )
     {
+#ifdef EXIT_ON_LOST_MOVER
+        ERROR( ( "Pipeline %i (species = %s) ran out of storage for %i movers.  This is an extremely serious problem that affects the physics of your run.",
+                    rank,
+                    sp->name,
+                    args->seg[rank].n_ignored ) );
+#else
         // If you see this warning, particles are essentially being held at the
         // boundary instead of finishing their move. They are now in the wrong
         // place and have not deposited correct currents....
@@ -319,6 +325,7 @@ advance_p_pipeline( species_t * RESTRICT sp,
                     rank,
                     sp->name,
                     args->seg[rank].n_ignored ) );
+#endif
     }
 
     if ( sp->pm + sp->nm != args->seg[rank].pm )

--- a/src/species_advance/standard/pipeline/advance_p_pipeline_v16.cc
+++ b/src/species_advance/standard/pipeline/advance_p_pipeline_v16.cc
@@ -377,25 +377,7 @@ advance_p_pipeline_v16( advance_p_pipeline_args_t * args,
     // particles.
     //--------------------------------------------------------------------------
 
-    #define MOVE_OUTBND(N)                                              \
-    if ( outbnd(N) )                                /* Unlikely */      \
-    {                                                                   \
-      local_pm->dispx = ux(N);                                          \
-      local_pm->dispy = uy(N);                                          \
-      local_pm->dispz = uz(N);                                          \
-      local_pm->i     = ( p - p0 ) + N;                                 \
-      if ( move_p( p0, local_pm, a0, g, _qsp ) )    /* Unlikely */      \
-      {                                                                 \
-        if ( nm < max_nm )                                              \
-        {                                                               \
-          v4::copy_4x1( &pm[nm++], local_pm );                          \
-        }                                                               \
-        else                                        /* Unlikely */      \
-        {                                                               \
-          itmp++;                                                       \
-        }                                                               \
-      }                                                                 \
-    }
+    #include "move_outbnd_v4.inc"
 
     MOVE_OUTBND( 0);
     MOVE_OUTBND( 1);

--- a/src/species_advance/standard/pipeline/advance_p_pipeline_v4.cc
+++ b/src/species_advance/standard/pipeline/advance_p_pipeline_v4.cc
@@ -277,25 +277,7 @@ advance_p_pipeline_v4( advance_p_pipeline_args_t * args,
     // particles.
     //--------------------------------------------------------------------------
 
-    #define MOVE_OUTBND(N)                                              \
-    if ( outbnd(N) )                                /* Unlikely */      \
-    {                                                                   \
-      local_pm->dispx = ux(N);                                          \
-      local_pm->dispy = uy(N);                                          \
-      local_pm->dispz = uz(N);                                          \
-      local_pm->i     = ( p - p0 ) + N;                                 \
-      if ( move_p( p0, local_pm, a0, g, _qsp ) )    /* Unlikely */      \
-      {                                                                 \
-        if ( nm < max_nm )                                              \
-        {                                                               \
-          copy_4x1( &pm[nm++], local_pm );                              \
-        }                                                               \
-        else                                        /* Unlikely */      \
-        {                                                               \
-          itmp++;                                                       \
-        }                                                               \
-      }                                                                 \
-    }
+    #include "move_outbnd_v4.inc"
 
     MOVE_OUTBND( 0);
     MOVE_OUTBND( 1);

--- a/src/species_advance/standard/pipeline/advance_p_pipeline_v8.cc
+++ b/src/species_advance/standard/pipeline/advance_p_pipeline_v8.cc
@@ -346,25 +346,7 @@ advance_p_pipeline_v8( advance_p_pipeline_args_t * args,
     // particles.
     //--------------------------------------------------------------------------
 
-#   define MOVE_OUTBND(N)                                               \
-    if ( outbnd(N) )                                /* Unlikely */      \
-    {                                                                   \
-      local_pm->dispx = ux(N);                                          \
-      local_pm->dispy = uy(N);                                          \
-      local_pm->dispz = uz(N);                                          \
-      local_pm->i     = ( p - p0 ) + N;                                 \
-      if ( move_p( p0, local_pm, a0, g, _qsp ) )    /* Unlikely */      \
-      {                                                                 \
-        if ( nm < max_nm )                                              \
-        {                                                               \
-          v4::copy_4x1( &pm[nm++], local_pm );                          \
-        }                                                               \
-        else                                        /* Unlikely */      \
-        {                                                               \
-          itmp++;                                                       \
-        }                                                               \
-      }                                                                 \
-    }
+    #include "move_outbnd_v4.inc"
 
     MOVE_OUTBND( 0);
     MOVE_OUTBND( 1);

--- a/src/species_advance/standard/pipeline/move_outbnd_v4.inc
+++ b/src/species_advance/standard/pipeline/move_outbnd_v4.inc
@@ -1,0 +1,28 @@
+// Macro that is to be included inside advance_p pipelined variants.
+// In an ideal world this would not exist, and the pipeline code would not be
+// repeated in multiple files
+// This is done so this common element can appear only once, instead of once
+// per file
+#define MOVE_OUTBND(N)                                              \
+if ( outbnd(N) )                                /* Unlikely */      \
+{                                                                   \
+    local_pm->dispx = ux(N);                                          \
+    local_pm->dispy = uy(N);                                          \
+    local_pm->dispz = uz(N);                                          \
+    local_pm->i     = ( p - p0 ) + N;                                 \
+    if ( move_p( p0, local_pm, a0, g, _qsp ) )    /* Unlikely */      \
+    {                                                                 \
+        if ( nm < max_nm )                                              \
+        {                                                               \
+            copy_4x1( &pm[nm++], local_pm );                              \
+        }                                                               \
+        else                                        /* Unlikely */      \
+        {                                                               \
+            itmp++;                                                       \
+          /* Also undo the shift that move_p did, to keep p->i in a valid range */ \
+          /* If we got here, we're running the risk of ruining the physics of  */\
+          /* the simulation. Take the mover warning very seriously. */ \
+          p0[ local_pm->i ].i = p0[ local_pm->i].i >> 3; \
+        }                                                               \
+    }                                                                 \
+}

--- a/src/species_advance/standard/pipeline/move_outbnd_v4.inc
+++ b/src/species_advance/standard/pipeline/move_outbnd_v4.inc
@@ -6,23 +6,25 @@
 #define MOVE_OUTBND(N)                                              \
 if ( outbnd(N) )                                /* Unlikely */      \
 {                                                                   \
-    local_pm->dispx = ux(N);                                          \
-    local_pm->dispy = uy(N);                                          \
-    local_pm->dispz = uz(N);                                          \
-    local_pm->i     = ( p - p0 ) + N;                                 \
-    if ( move_p( p0, local_pm, a0, g, _qsp ) )    /* Unlikely */      \
-    {                                                                 \
-        if ( nm < max_nm )                                              \
-        {                                                               \
-            copy_4x1( &pm[nm++], local_pm );                              \
-        }                                                               \
-        else                                        /* Unlikely */      \
-        {                                                               \
-            itmp++;                                                       \
-          /* Also undo the shift that move_p did, to keep p->i in a valid range */ \
-          /* If we got here, we're running the risk of ruining the physics of  */\
-          /* the simulation. Take the mover warning very seriously. */ \
-          p0[ local_pm->i ].i = p0[ local_pm->i].i >> 3; \
-        }                                                               \
-    }                                                                 \
+    local_pm->dispx = ux(N);                                        \
+    local_pm->dispy = uy(N);                                        \
+    local_pm->dispz = uz(N);                                        \
+    local_pm->i     = ( p - p0 ) + N;                               \
+    if ( move_p( p0, local_pm, a0, g, _qsp ) )    /* Unlikely */    \
+    {                                                               \
+        if ( nm < max_nm )                                          \
+        {                                                           \
+            /* fully qualify to use in contexts with imported namespace */   \
+            ::v4::copy_4x1( &pm[nm++], local_pm );                  \
+        }                                                           \
+        else                                        /* Unlikely */  \
+        {                                                           \
+            itmp++;                                                 \
+          /* Also undo the shift that move_p did, to keep p->i in a valid */ \
+          /* range. If we got here, we're running the risk of ruining the */ \
+          /* physics of the simulation. */                                   \
+          /* Take the mover warning **very** seriously. */                   \
+          p0[ local_pm->i ].i = p0[ local_pm->i].i >> 3;            \
+        }                                                           \
+    }                                                               \
 }


### PR DESCRIPTION
Previously, if movers were lost the following would happen:

1) The user would get a warning,
2) The particle->i value would be shifted by move_p to be out of bounds
3) The particle never makes it to boundary_p in order to processes it

This either teleports the particle across the domain; or causes a
segfault in the next timestep.

This PR:

1) Adds some notes to the user about how serious that warning is
2) Undoes the shift, so instead of segfauliting the code now "holds" the
particle at the cell boundary

This breaks physics, but to a lesser extent than the previous
teleporting of a particle. It's still crucial the user uses a correct
value for nm

To recreate these issues just use a deck where the intial nm is set to 1
during define_species in the input deck