### PR TITLE
Fix warnings

### DIFF
--- a/src/collision/hard_sphere.cc
+++ b/src/collision/hard_sphere.cc
@@ -303,7 +303,7 @@ hard_sphere_fluid_collision( const hard_sphere_t * RESTRICT hs,
     urz -= w*frandn(rng);
   }
   
-  COMPUTE_MOMENTUM_TRANSFER(urx,urz,urz,ax,ay,az,rng);
+  COMPUTE_MOMENTUM_TRANSFER(urx,ury,urz,ax,ay,az,rng);
 
   w = hs->twomu_mi;
   pi->ux -= w*ax;

--- a/src/collision/large_angle_coulomb.cc
+++ b/src/collision/large_angle_coulomb.cc
@@ -150,7 +150,7 @@ large_angle_coulomb_fluid_collision(
     urz -= w*frandn(rng);
   }
   
-  COMPUTE_MOMENTUM_TRANSFER(urx,urz,urz,ax,ay,az,rng);
+  COMPUTE_MOMENTUM_TRANSFER(urx,ury,urz,ax,ay,az,rng);
 
   w = lac->twomu_mi;
   pi->ux -= w*ax;

--- a/src/collision/pipeline/takizuka_abe_pipeline.cc
+++ b/src/collision/pipeline/takizuka_abe_pipeline.cc
@@ -101,8 +101,8 @@ takizuka_abe_pipeline_scalar( takizuka_abe_t * RESTRICT cm,
   const double cvar = cm->cvar0 * (spi->q*spi->q*spj->q*spj->q) / (mu*mu);
 
   particle_t ptemp;
-  float var, std, density_k, density_l;
-  int i, j, ii, rn, v, v1, k, k0, k1, nk, l, l0, nl, size_k, size_l;
+  float std, density_k, density_l;
+  int i, j, ii, rn, v, v1, k0, k1, nk, l0, nl;
 
   /* Stripe the (mostly non-ghost) voxels over threads for load balance */
 

--- a/src/sf_interface/pipeline/reduce_array_pipeline.cc
+++ b/src/sf_interface/pipeline/reduce_array_pipeline.cc
@@ -23,7 +23,6 @@ reduce_array_pipeline_scalar( reduce_pipeline_args_t * args,
                               int n_pipeline )
 {
   int i, i1, j, r0;
-  int r;
   int nr = args->n_array - 1;
   int sr = args->s_array;
 

--- a/src/sf_interface/pipeline/reduce_array_pipeline_v16.cc
+++ b/src/sf_interface/pipeline/reduce_array_pipeline_v16.cc
@@ -14,7 +14,6 @@ reduce_array_pipeline_v16( reduce_pipeline_args_t * args,
                            int n_pipeline )
 {
   int i, i1, j, r0;
-  int r;
   int nr = args->n_array - 1;
   int sr = args->s_array;
 

--- a/src/sf_interface/pipeline/reduce_array_pipeline_v4.cc
+++ b/src/sf_interface/pipeline/reduce_array_pipeline_v4.cc
@@ -14,7 +14,6 @@ reduce_array_pipeline_v4( reduce_pipeline_args_t * args,
                           int n_pipeline )
 {
   int i, i1, j, r0;
-  int r;
   int nr = args->n_array - 1;
   int sr = args->s_array;
 

--- a/src/sf_interface/pipeline/reduce_array_pipeline_v8.cc
+++ b/src/sf_interface/pipeline/reduce_array_pipeline_v8.cc
@@ -14,7 +14,6 @@ reduce_array_pipeline_v8( reduce_pipeline_args_t * args,
                           int n_pipeline )
 {
   int i, i1, j, r0;
-  int r;
   int nr = args->n_array - 1;
   int sr = args->s_array;
 

--- a/src/species_advance/standard/pipeline/hydro_p_pipeline.cc
+++ b/src/species_advance/standard/pipeline/hydro_p_pipeline.cc
@@ -22,7 +22,6 @@ accumulate_hydro_p_pipeline_scalar( accumulate_hydro_p_pipeline_args_t * args,
                                     int n_pipeline )
 {
   const species_t      *              sp = args->sp;
-  const grid_t         *              g  = sp->g;
   /**/  hydro_t        * ALIGNED(128) h  = args->h + pipeline_rank * args->h_size;
   const particle_t     * ALIGNED(128) p  = sp->p;
   const interpolator_t * ALIGNED(128) f  = args->f;
@@ -36,14 +35,12 @@ accumulate_hydro_p_pipeline_scalar( accumulate_hydro_p_pipeline_args_t * args,
   const float c        = sp->g->cvac;
   const float r8V      = sp->g->r8V;
 
-  const float zero           = 0.0;
   const float one            = 1.0;
   const float one_third      = 1.0 / 3.0;
-  const float two_fifteenths = 2.0 / 15.0;
 
   float dx, dy, dz, ux, uy, uz, w, vx, vy, vz, ke_mc;
   float t, w0, w1, w2, w3, w4, w5, w6, w7;
-  int   i, n, n1, n0, np;
+  int   i, n, n1, n0;
 
   int   stride_10;
   int   stride_21;

--- a/src/util/util_base.cc
+++ b/src/util/util_base.cc
@@ -58,9 +58,6 @@ int string_starts_with(const char *str, const char *pre)
 
 int string_contains(const char *str, const char *substr)
 {
-    const char *output = NULL;
-    output = strstr(str,substr);
-
     const char* pos = strstr(str, substr);
 
     if (pos) {
@@ -110,11 +107,11 @@ void detect_old_style_arguments(int* pargc, char *** pargv)
           // Search for tpp
           if (string_starts_with(arg,prefix_keys[j]))
           {
-              char output_message[64];
+              char output_message[128];
 
               sprintf(output_message,
-                  "Aborting. Single dashed flag %1$s is invalid (needs '-%1$s').",
-                  prefix_keys[j]
+                  "Aborting. Single dashed flag %s is invalid (needs '-%s').",
+                  prefix_keys[j],prefix_keys[j]
               );
 
               WARNING(( "Input Flags Look Like They Are Using Legacy Style."));

--- a/src/util/v16/v16_avx512.h
+++ b/src/util/v16/v16_avx512.h
@@ -2046,10 +2046,7 @@ namespace v16
 
     v16int() {}                                  // Default constructor
 
-    v16int( const v16int &a )                    // Copy constructor
-    {
-      v = a.v;
-    }
+    v16int( const v16int &a ) : v16(a) {}        // Copy constructor from v16
 
     v16int( const v16 &a )                       // Init from mixed
     {
@@ -2449,10 +2446,7 @@ namespace v16
 
     v16float() {}                                          // Default constructor
 
-    v16float( const v16float &a )                          // Copy constructor
-    {
-      v = a.v;
-    }
+    v16float( const v16float &a ) : v16(a) {}              // Copy constructor from v16
 
     v16float( const v16 &a )                               // Init from mixed
     {

--- a/src/util/v16/v16_portable.h
+++ b/src/util/v16/v16_portable.h
@@ -3039,13 +3039,7 @@ namespace v16
 
     v16int() {}                                  // Default constructor
 
-    v16int( const v16int &a )                    // Copy constructor
-    {
-      i[ 0] = a.i[ 0]; i[ 1] = a.i[ 1]; i[ 2] = a.i[ 2]; i[ 3] = a.i[ 3];
-      i[ 4] = a.i[ 4]; i[ 5] = a.i[ 5]; i[ 6] = a.i[ 6]; i[ 7] = a.i[ 7];
-      i[ 8] = a.i[ 8]; i[ 9] = a.i[ 9]; i[10] = a.i[10]; i[11] = a.i[11];
-      i[12] = a.i[12]; i[13] = a.i[13]; i[14] = a.i[14]; i[15] = a.i[15];
-    }
+    v16int( const v16int &a ) : v16(a) {}        // Copy constructor from v16
 
     v16int( const v16 &a )                       // Init from mixed
     {
@@ -3493,7 +3487,7 @@ namespace v16
 
     v16float() {}                                          // Default constructor
 
-    v16float( const v16float &a )                          // Copy constructor
+    v16float( const v16float &a ) : v16()                  // Copy constructor
     {
       f[ 0] = a.f[ 0]; f[ 1] = a.f[ 1]; f[ 2] = a.f[ 2]; f[ 3] = a.f[ 3];
       f[ 4] = a.f[ 4]; f[ 5] = a.f[ 5]; f[ 6] = a.f[ 6]; f[ 7] = a.f[ 7];

--- a/src/util/v16/v16_portable_v0.h
+++ b/src/util/v16/v16_portable_v0.h
@@ -3039,13 +3039,7 @@ namespace v16
 
     v16int() {}                                  // Default constructor
 
-    v16int( const v16int &a )                    // Copy constructor
-    {
-      i[ 0] = a.i[ 0]; i[ 1] = a.i[ 1]; i[ 2] = a.i[ 2]; i[ 3] = a.i[ 3];
-      i[ 4] = a.i[ 4]; i[ 5] = a.i[ 5]; i[ 6] = a.i[ 6]; i[ 7] = a.i[ 7];
-      i[ 8] = a.i[ 8]; i[ 9] = a.i[ 9]; i[10] = a.i[10]; i[11] = a.i[11];
-      i[12] = a.i[12]; i[13] = a.i[13]; i[14] = a.i[14]; i[15] = a.i[15];
-    }
+    v16int( const v16int &a ) : v16(a) {}        // Copy constructor from v16
 
     v16int( const v16 &a )                       // Init from mixed
     {
@@ -3493,7 +3487,7 @@ namespace v16
 
     v16float() {}                                          // Default constructor
 
-    v16float( const v16float &a )                          // Copy constructor
+    v16float( const v16float &a ) : v16()                  // Copy constructor
     {
       f[ 0] = a.f[ 0]; f[ 1] = a.f[ 1]; f[ 2] = a.f[ 2]; f[ 3] = a.f[ 3];
       f[ 4] = a.f[ 4]; f[ 5] = a.f[ 5]; f[ 6] = a.f[ 6]; f[ 7] = a.f[ 7];

--- a/src/util/v16/v16_portable_v1.h
+++ b/src/util/v16/v16_portable_v1.h
@@ -2903,12 +2903,7 @@ namespace v16
 
     v16int() {}                                  // Default constructor
 
-    v16int( const v16int &a )                    // Copy constructor
-    {
-      ALWAYS_VECTORIZE
-      for( int j = 0; j < 16; j++ )
-	i[j] = a.i[j];
-    }
+    v16int( const v16int &a ) : v16(a) {}        // Copy constructor from v16
 
     v16int( const v16 &a )                       // Init from mixed
     {
@@ -3213,7 +3208,7 @@ namespace v16
 
     v16float() {}                                          // Default constructor
 
-    v16float( const v16float &a )                          // Copy constructor
+    v16float( const v16float &a ) : v16()                  // Copy constructor
     {
       ALWAYS_VECTORIZE
       for( int j = 0; j < 16; j++ )

--- a/src/util/v4/v4_altivec.h
+++ b/src/util/v4/v4_altivec.h
@@ -582,10 +582,7 @@ namespace v4
 
     v4int() {}                                // Default constructor
 
-    v4int( const v4int &a )                   // Copy constructor
-    {
-      v = a.v;
-    }
+    v4int( const v4int &a ) : v4(a) {}        // Copy constructor from v4
 
     v4int( const v4 &a )                      // Init from mixed
     {
@@ -927,10 +924,7 @@ namespace v4
 
     v4float() {}                                        // Default constructor
 
-    v4float( const v4float &a )                         // Copy constructor
-    {
-      v = a.v;
-    }
+    v4float( const v4float &a ) : v4(a) {}              // Copy constructor from v4
 
     v4float( const v4 &a )                              // Init from mixed
     {

--- a/src/util/v4/v4_avx.h
+++ b/src/util/v4/v4_avx.h
@@ -267,7 +267,7 @@ namespace v4
                            v4 &a,
                            v4 &b )
   {
-    __m128 a_v, b_v, t;
+    __m128 b_v, t;
 
     b_v = _mm_setzero_ps();
 
@@ -499,10 +499,7 @@ namespace v4
 
     v4int() {}                                // Default constructor
 
-    v4int( const v4int &a )                   // Copy constructor
-    {
-      v = a.v;
-    }
+    v4int( const v4int &a ) : v4(a) {}        // Copy constructor from v4
 
     v4int( const v4 &a )                      // Init from mixed
     {
@@ -892,10 +889,7 @@ namespace v4
 
     v4float() {}                                        // Default constructor
 
-    v4float( const v4float &a )                         // Copy constructor
-    {
-      v = a.v;
-    }
+    v4float( const v4float &a ) : v4(a) {}              // Copy constructor from v4
 
     v4float( const v4 &a )                              // Init from mixed
     {

--- a/src/util/v4/v4_avx2.h
+++ b/src/util/v4/v4_avx2.h
@@ -267,7 +267,7 @@ namespace v4
                            v4 &a,
                            v4 &b )
   {
-    __m128 a_v, b_v, t;
+    __m128 b_v, t;
 
     b_v = _mm_setzero_ps();
 
@@ -644,10 +644,7 @@ namespace v4
 
     v4int() {}                                // Default constructor
 
-    v4int( const v4int &a )                   // Copy constructor
-    {
-      v = a.v;
-    }
+    v4int( const v4int &a ) : v4(a) {}        // Copy constructor from v4
 
     v4int( const v4 &a )                      // Init from mixed
     {
@@ -1037,10 +1034,7 @@ namespace v4
 
     v4float() {}                                        // Default constructor
 
-    v4float( const v4float &a )                         // Copy constructor
-    {
-      v = a.v;
-    }
+    v4float( const v4float &a ) : v4(a) {}              // Copy constructor from v4
 
     v4float( const v4 &a )                              // Init from mixed
     {

--- a/src/util/v4/v4_neon.h
+++ b/src/util/v4/v4_neon.h
@@ -736,10 +736,7 @@ namespace v4
 
     v4int() {}                                // Default constructor
 
-    v4int( const v4int &a )                   // Copy constructor
-    {
-      v = a.v;
-    }
+    v4int( const v4int &a ) : v4(a) {}        // Copy constructor from v4
 
     v4int( const v4 &a )                      // Init from mixed
     {
@@ -1125,10 +1122,7 @@ namespace v4
 
     v4float() {}                                        // Default constructor
 
-    v4float( const v4float &a )                         // Copy constructor
-    {
-      v = a.v;
-    }
+    v4float( const v4float &a ) : v4(a) {}              // Copy constructor from v4
 
     v4float( const v4 &a )                              // Init from mixed
     {

--- a/src/util/v4/v4_portable.h
+++ b/src/util/v4/v4_portable.h
@@ -525,13 +525,7 @@ namespace v4
 
     v4int() {}                                // Default constructor
 
-    v4int( const v4int &a )                   // Copy constructor
-    {
-      i[0] = a.i[0];
-      i[1] = a.i[1];
-      i[2] = a.i[2];
-      i[3] = a.i[3];
-    }
+    v4int( const v4int &a ) : v4(a) {}        // Copy constructor from v4
 
     v4int( const v4 &a )                      // Init from mixed
     {
@@ -847,7 +841,7 @@ namespace v4
 
     v4float() {}                                        // Default constructor
 
-    v4float( const v4float &a )                         // Copy constructor
+    v4float( const v4float &a ) : v4()                  // Copy constructor
     {
       f[0] = a.f[0];
       f[1] = a.f[1];

--- a/src/util/v4/v4_portable_v0.h
+++ b/src/util/v4/v4_portable_v0.h
@@ -525,13 +525,7 @@ namespace v4
 
     v4int() {}                                // Default constructor
 
-    v4int( const v4int &a )                   // Copy constructor
-    {
-      i[0] = a.i[0];
-      i[1] = a.i[1];
-      i[2] = a.i[2];
-      i[3] = a.i[3];
-    }
+    v4int( const v4int &a ) : v4(a) {}        // Copy constructor from v4
 
     v4int( const v4 &a )                      // Init from mixed
     {
@@ -847,7 +841,7 @@ namespace v4
 
     v4float() {}                                        // Default constructor
 
-    v4float( const v4float &a )                         // Copy constructor
+    v4float( const v4float &a ) : v4()                  // Copy constructor
     {
       f[0] = a.f[0];
       f[1] = a.f[1];

--- a/src/util/v4/v4_portable_v1.h
+++ b/src/util/v4/v4_portable_v1.h
@@ -517,12 +517,7 @@ namespace v4
 
     v4int() {}                                // Default constructor
 
-    v4int( const v4int &a )                   // Copy constructor
-    {
-      ALWAYS_VECTORIZE
-      for( int j = 0; j < 4; j++ )
-        i[j] = a.i[j];
-    }
+    v4int( const v4int &a ) : v4(a) {}        // Copy constructor from v4
 
     v4int( const v4 &a )                      // Init from mixed
     {
@@ -825,7 +820,7 @@ namespace v4
 
     v4float() {}                                        // Default constructor
 
-    v4float( const v4float &a )                         // Copy constructor
+    v4float( const v4float &a ) : v4()                  // Copy constructor
     {
       ALWAYS_VECTORIZE
       for( int j = 0; j < 4; j++ )

--- a/src/util/v4/v4_sse.h
+++ b/src/util/v4/v4_sse.h
@@ -511,10 +511,7 @@ namespace v4
 
     v4int() {}                                // Default constructor
 
-    v4int( const v4int &a )                   // Copy constructor
-    {
-      v = a.v;
-    }
+    v4int( const v4int &a ) : v4(a) {}        // Copy constructor from v4
 
     v4int( const v4 &a )                      // Init from mixed
     {
@@ -904,10 +901,7 @@ namespace v4
 
     v4float() {}                                        // Default constructor
 
-    v4float( const v4float &a )                         // Copy constructor
-    {
-      v = a.v;
-    }
+    v4float( const v4float &a ) : v4(a) {}              // Copy constructor from v4
 
     v4float( const v4 &a )                              // Init from mixed
     {

--- a/src/util/v8/v8_avx.h
+++ b/src/util/v8/v8_avx.h
@@ -804,10 +804,7 @@ namespace v8
 
     v8int() {}                                // Default constructor
 
-    v8int( const v8int &a )                   // Copy constructor
-    {
-      v = a.v;
-    }
+    v8int( const v8int &a ) : v8(a) {}        // Copy constructor from v8
 
     v8int( const v8 &a )                      // Init from mixed
     {
@@ -1225,10 +1222,7 @@ namespace v8
 
     v8float() {}                                        // Default constructor
 
-    v8float( const v8float &a )                         // Copy constructor
-    {
-      v = a.v;
-    }
+    v8float( const v8float &a ) : v8(a) {}              // Copy constructor from v8
 
     v8float( const v8 &a )                              // Init from mixed
     {

--- a/src/util/v8/v8_avx2.h
+++ b/src/util/v8/v8_avx2.h
@@ -1000,10 +1000,7 @@ namespace v8
 
     v8int() {}                                // Default constructor
 
-    v8int( const v8int &a )                   // Copy constructor
-    {
-      v = a.v;
-    }
+    v8int( const v8int &a ) : v8(a) {}        // Copy constructor from v8
 
     v8int( const v8 &a )                      // Init from mixed
     {
@@ -1421,10 +1418,7 @@ namespace v8
 
     v8float() {}                                        // Default constructor
 
-    v8float( const v8float &a )                         // Copy constructor
-    {
-      v = a.v;
-    }
+    v8float( const v8float &a ) : v8(a) {}              // Copy constructor from v8
 
     v8float( const v8 &a )                              // Init from mixed
     {

--- a/src/util/v8/v8_portable.h
+++ b/src/util/v8/v8_portable.h
@@ -885,11 +885,7 @@ namespace v8
 
     v8int() {}                                // Default constructor
 
-    v8int( const v8int &a )                   // Copy constructor
-    {
-      i[0] = a.i[0]; i[1] = a.i[1]; i[2] = a.i[2]; i[3] = a.i[3];
-      i[4] = a.i[4]; i[5] = a.i[5]; i[6] = a.i[6]; i[7] = a.i[7];
-    }
+    v8int( const v8int &a ) : v8(a) {}        // Copy constructor from v8
 
     v8int( const v8 &a )                      // Init from mixed
     {
@@ -1243,7 +1239,7 @@ namespace v8
 
     v8float() {}                                        // Default constructor
 
-    v8float( const v8float &a )                         // Copy constructor
+    v8float( const v8float &a ) : v8()                  // Copy constructor
     {
       f[0] = a.f[0];
       f[1] = a.f[1];

--- a/src/util/v8/v8_portable_v0.h
+++ b/src/util/v8/v8_portable_v0.h
@@ -885,11 +885,7 @@ namespace v8
 
     v8int() {}                                // Default constructor
 
-    v8int( const v8int &a )                   // Copy constructor
-    {
-      i[0] = a.i[0]; i[1] = a.i[1]; i[2] = a.i[2]; i[3] = a.i[3];
-      i[4] = a.i[4]; i[5] = a.i[5]; i[6] = a.i[6]; i[7] = a.i[7];
-    }
+    v8int( const v8int &a ) : v8(a) {}        // Copy constructor from v8
 
     v8int( const v8 &a )                      // Init from mixed
     {
@@ -1243,7 +1239,7 @@ namespace v8
 
     v8float() {}                                        // Default constructor
 
-    v8float( const v8float &a )                         // Copy constructor
+    v8float( const v8float &a ) : v8()                  // Copy constructor
     {
       f[0] = a.f[0];
       f[1] = a.f[1];

--- a/src/util/v8/v8_portable_v1.h
+++ b/src/util/v8/v8_portable_v1.h
@@ -839,12 +839,7 @@ namespace v8
 
     v8int() {}                                // Default constructor
 
-    v8int( const v8int &a )                   // Copy constructor
-    {
-      ALWAYS_VECTORIZE
-      for( int j = 0; j < 8; j++ )
-	i[j] = a.i[j];
-    }
+    v8int( const v8int &a ) : v8(a) {}        // Copy constructor from v8
 
     v8int( const v8 &a )                      // Init from mixed
     {
@@ -1151,7 +1146,7 @@ namespace v8
 
     v8float() {}                                        // Default constructor
 
-    v8float( const v8float &a )                         // Copy constructor
+    v8float( const v8float &a ) : v8()                  // Copy constructor
     {
       ALWAYS_VECTORIZE
       for( int j = 0; j < 8; j++ )

--- a/src/vpic/dump.cc
+++ b/src/vpic/dump.cc
@@ -548,7 +548,7 @@ vpic_simulation::field_dump( DumpParameters & dumpParams,
   dump_mkdir( timeDir );
 
   // Open the file for output
-  char filename[256];
+  char filename[300];
 
   sprintf( filename,
            "%s/T.%ld/%s.%ld.%d",
@@ -724,7 +724,7 @@ vpic_simulation::hydro_dump( const char * speciesname,
   dump_mkdir( timeDir );
 
   // Open the file for output
-  char filename[256];
+  char filename[300];
 
   sprintf( filename,
            "%s/T.%ld/%s.%ld.%d",

--- a/test/integrated/collision/test_collision.deck
+++ b/test/integrated/collision/test_collision.deck
@@ -38,19 +38,19 @@ begin_initialization {
   double de   = 1;         // Length normalization (electron inertial length)
   double eps0 = 1;         // Permittivity of space
 
-  double cfl_req   = 0.99;  // How close to Courant should we try to run
-  double wpedt_max = 0.36;  // Max dt allowed if Courant not too restrictive
-  double damp      = 0.0;   // Level of radiation damping
-  int rng_seed     = 1;     // Random number seed increment
+  //double cfl_req   = 0.99;  // How close to Courant should we try to run
+  //double wpedt_max = 0.36;  // Max dt allowed if Courant not too restrictive
+  //double damp      = 0.0;   // Level of radiation damping
+  //int rng_seed     = 1;     // Random number seed increment
 
   // Physics parameters
   double mi_me   = 1836.0;   // Ion mass / electron mass
   double Te      = 0.001;     // Electron temperature in m_ec^2
   double Ti_Te   = 1.0;      // Ion temperature / electron temperature
   double n0      = 1.0;      // Density
-  double Z       = 1.0;      // Ion charge
+  //double Z       = 1.0;      // Ion charge
   double vdre_vthe =  1.0;   // 1 gives Fig. 8a in Takizuka & Abe (1977)
-  double taue    = 1.0*sqrt(2.0);      // simulation tau_e's to run
+  //double taue    = 1.0*sqrt(2.0);      // simulation tau_e's to run
 
   double quota   = 0.1;   // run quota in hours
   double quota_sec = quota*3600;  // Run quota in seconds
@@ -127,12 +127,12 @@ begin_initialization {
     (iz) = _iz;                                                         \
   } END_PRIMITIVE
 
-  int ix, iy, iz, left=0,right=0,top=0,bottom=0;
-  RANK_TO_INDEX( int(rank()), ix, iy, iz );
-  if ( ix ==0 ) left=1;
-  if ( ix ==topology_x-1 ) right=1;
-  if ( iz ==0 ) bottom=1;
-  if ( iz ==topology_z-1 ) top=1;
+  //int ix, iy, iz, left=0,right=0,top=0,bottom=0;
+  //RANK_TO_INDEX( int(rank()), ix, iy, iz );
+  //if ( ix ==0 ) left=1;
+  //if ( ix ==topology_x-1 ) right=1;
+  //if ( iz ==0 ) bottom=1;
+  //if ( iz ==topology_z-1 ) top=1;
 
   ///////////////////////////////////////////////
   // Setup high level simulation parameters
@@ -570,10 +570,6 @@ begin_diagnostics {
    * THE LOCATION OF THE GLOBAL HEADER!!!
    *------------------------------------------------------------------------*/
 
-  const int nx=grid->nx;
-  const int ny=grid->ny;
-  const int nz=grid->nz;
-
   /*--------------------------------------------------------------------------
    * Normal rundata dump
    *------------------------------------------------------------------------*/
@@ -638,15 +634,15 @@ begin_diagnostics {
   if ( should_dump(eparticle) && step() !=0
        && step() > 56*(global->fields_interval)  ) {
     // if ( should_dump(eparticle) && step() !=0 ) {
-    sprintf(subdir,"particle/T.%lld",step());
+    sprintf(subdir,"particle/T.%lld",(long long)step());
     dump_mkdir(subdir);
-    sprintf(subdir,"particle/T.%lld/eparticle",step());
+    sprintf(subdir,"particle/T.%lld/eparticle",(long long)step());
     dump_particles("electron", subdir);
   }
 
   if ( should_dump(Hparticle) && step() !=0
        && step() > 56*(global->fields_interval)  ) {
-    sprintf(subdir,"particle/T.%lld/Hparticle",step());
+    sprintf(subdir,"particle/T.%lld/Hparticle",(long long)step());
     dump_particles("ion", subdir);
   }
 

--- a/test/integrated/collision/test_collision.deck
+++ b/test/integrated/collision/test_collision.deck
@@ -193,9 +193,11 @@ begin_initialization {
 
   // Define resistive layer surrounding boundary --> set thickness=0
   // to eliminate this feature
-  //double thickness = 2;
-  //#define resistive_layer (x < hx*thickness || x > Lx-hx*thickness	\
-  //                     || z <-Lz/2+hz*thickness  || z > Lz/2-hz*thickness )
+  /*
+  double thickness = 2;
+  #define resistive_layer (x < hx*thickness || x > Lx-hx*thickness	\
+                       || z <-Lz/2+hz*thickness  || z > Lz/2-hz*thickness )
+  */
 
   //if (thickness > 0)
   // set_region_material(resistive_layer, resistive, resistive);

--- a/test/integrated/to_completion/reconnection_test.deck
+++ b/test/integrated/to_completion/reconnection_test.deck
@@ -596,15 +596,15 @@ begin_diagnostics {
     char subdir[36];
     if(should_dump(particle))
     {
-        sprintf(subdir,"particle/T.%lld",step());
+        sprintf(subdir,"particle/T.%lld",(long long)step());
         dump_mkdir(subdir);
-        sprintf(subdir,"particle/T.%lld/eparticle1",step());
+        sprintf(subdir,"particle/T.%lld/eparticle1",(long long)step());
         dump_particles("electron1",subdir);
-        sprintf(subdir,"particle/T.%lld/eparticle2",step());
+        sprintf(subdir,"particle/T.%lld/eparticle2",(long long)step());
         dump_particles("electron2",subdir);
-        sprintf(subdir,"particle/T.%lld/Hparticle1",step());
+        sprintf(subdir,"particle/T.%lld/Hparticle1",(long long)step());
         dump_particles("ion1",subdir);
-        sprintf(subdir,"particle/T.%lld/Hparticle2",step());
+        sprintf(subdir,"particle/T.%lld/Hparticle2",(long long)step());
         dump_particles("ion2",subdir);
     }
 

--- a/test/unit/energy_comparison/3d_test.cc
+++ b/test/unit/energy_comparison/3d_test.cc
@@ -327,9 +327,9 @@ TEST_CASE( "Check if Weibel gives correct energy (within tol)", "[energy]" )
         energy_gold_file_name << std::endl;
 
     // Compare energies to make sure everything worked out OK (within 1%)
-    const unsigned short e_mask = 0b0000001110;
-    const unsigned short b_mask = 0b0001110000;
-    const unsigned short particle_mask = 0b011000000;
+    const unsigned short e_mask = 0x000E; // = 0b0000001110; <- Non-standard C++11
+    const unsigned short b_mask = 0x0070; // = 0b0001110000;    Requires C++14/GNU extensions
+    const unsigned short particle_mask = 0x00C0; // = 0b011000000;
 
     // Test the sum of the e_field
     REQUIRE(

--- a/test/unit/energy_comparison/compare_energies.h
+++ b/test/unit/energy_comparison/compare_energies.h
@@ -135,8 +135,9 @@ bool compare_energies(
         const std::string file_a,
         const std::string file_b,
         const double relative_tolerance,
-        const unsigned short field_mask = 0b1111111111111111, /// short has 16 bytes, assume all are true
-        const FIELD_ENUM field_enum = FIELD_ENUM::Individual, /// short has 16 bytes, assume all are true
+     /* const unsigned short field_mask = 0b1111111111111111, // Strictly, this requires C++14 or GNU extensions */
+        const unsigned short field_mask = 0xFFFF,             // short has 16 bits, assume all are true
+        const FIELD_ENUM field_enum = FIELD_ENUM::Individual, // short has 16 bits, assume all are true
         const int write_err_ouput = 0, // If the run should dump the errors to disk
         const std::string err_file_base_name =  "err.out", // File name to write errors to
         const int num_lines_to_skip = 0 // Most energy files have 3 lines of padding

--- a/test/unit/energy_comparison/weibel_driver.cc
+++ b/test/unit/energy_comparison/weibel_driver.cc
@@ -325,9 +325,9 @@ TEST_CASE( "Check if Weibel gives correct energy (within tol)", "[energy]" )
         energy_gold_file_name << std::endl;
 
     // Compare energies to make sure everything worked out OK (within 1%)
-    const unsigned short e_mask = 0b0000001110;
-    const unsigned short b_mask = 0b0001110000;
-    const unsigned short particle_mask = 0b011000000;
+    const unsigned short e_mask = 0x000E; // = 0b0000001110; <- Non-standard C++11
+    const unsigned short b_mask = 0x0070; // = 0b0001110000;    Requires C++14/GNU extensions
+    const unsigned short particle_mask = 0x00C0; // = 0b011000000;
 
     // Test the sum of the e_field
     REQUIRE(


### PR DESCRIPTION
This pull request fixes a couple of bugs and eliminates many of the warnings that I've been getting from gcc 9.3 and clang 10. The warning options I've used are "-Wall -Wextra -Wpedantic". See the commit messages for more details. The intention with this is not to remove warnings for the sake of it, but hopefully to improve the code by eliminating potential bugs, and making it more readable and standard compliant.

Someone who understands it better than me should check the 'correction' I made to the hard sphere and large angle Coulomb methods (commit e53ffd5). From looking at the code it looked like an obvious mistake but may be intentional, in which case the code should be changed to make the intention clear.

There are still several warnings that are printed, mostly relating to unused parameters in function calls. I've not thought of a good way of handling those, and since they are not actual bugs didn't want to change anything.