### PR TITLE
Fixes issue #146 where vectorized hydro_p has an extra momentum update.

### DIFF
--- a/src/species_advance/standard/pipeline/hydro_p_pipeline_v16.cc
+++ b/src/species_advance/standard/pipeline/hydro_p_pipeline_v16.cc
@@ -170,10 +170,6 @@ accumulate_hydro_p_pipeline_v16( accumulate_hydro_p_pipeline_args_t * args,
     uy   = fma( fms( v02, cbx, v00 * cbz ), v04, uy );
     uz   = fma( fms( v00, cby, v01 * cbx ), v04, uz );
 
-    ux  += hax;
-    uy  += hay;
-    uz  += haz;
-
     //--------------------------------------------------------------------------
     // Compute velocity.
     //--------------------------------------------------------------------------

--- a/src/species_advance/standard/pipeline/hydro_p_pipeline_v4.cc
+++ b/src/species_advance/standard/pipeline/hydro_p_pipeline_v4.cc
@@ -153,10 +153,6 @@ accumulate_hydro_p_pipeline_v4( accumulate_hydro_p_pipeline_args_t * args,
     uy   = fma( fms( v02, cbx, v00 * cbz ), v04, uy );
     uz   = fma( fms( v00, cby, v01 * cbx ), v04, uz );
 
-    ux  += hax;
-    uy  += hay;
-    uz  += haz;
-
     //--------------------------------------------------------------------------
     // Compute velocity.
     //--------------------------------------------------------------------------

--- a/src/species_advance/standard/pipeline/hydro_p_pipeline_v8.cc
+++ b/src/species_advance/standard/pipeline/hydro_p_pipeline_v8.cc
@@ -151,10 +151,6 @@ accumulate_hydro_p_pipeline_v8( accumulate_hydro_p_pipeline_args_t * args,
     uy   = fma( fms( v02, cbx, v00 * cbz ), v04, uy );
     uz   = fma( fms( v00, cby, v01 * cbx ), v04, uz );
 
-    ux  += hax;
-    uy  += hay;
-    uz  += haz;
-
     //--------------------------------------------------------------------------
     // Compute velocity.
     //--------------------------------------------------------------------------


### PR DESCRIPTION
I was able to create a test that showed a difference in output between unvectorized and v4.  The difference goes away with this fix.